### PR TITLE
Subtests support

### DIFF
--- a/ast/sources.go
+++ b/ast/sources.go
@@ -37,7 +37,7 @@ func GetFuncSourceFromCaller(skip int) *MethodCodeBoundaries {
 func GetFuncSourceForName(pc uintptr, name string) *MethodCodeBoundaries {
 	mFunc := runtime.FuncForPC(pc)
 	mFile, _ := mFunc.FileLine(pc)
-	fileCode, err := loadCodesForFile(mFile)
+	fileCode, err := getCodesForFile(mFile)
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
@@ -49,7 +49,7 @@ func GetFuncSourceForName(pc uintptr, name string) *MethodCodeBoundaries {
 func GetFuncSource(pc uintptr) *MethodCodeBoundaries {
 	mFunc := runtime.FuncForPC(pc)
 	mFile, _ := mFunc.FileLine(pc)
-	fileCode, err := loadCodesForFile(mFile)
+	fileCode, err := getCodesForFile(mFile)
 	if err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
@@ -60,7 +60,7 @@ func GetFuncSource(pc uintptr) *MethodCodeBoundaries {
 	return fileCode[funcName]
 }
 
-func loadCodesForFile(file string) (map[string]*MethodCodeBoundaries, error) {
+func getCodesForFile(file string) (map[string]*MethodCodeBoundaries, error) {
 	mutex.Lock()
 	if methodCodes == nil {
 		methodCodes = map[string]map[string]*MethodCodeBoundaries{}

--- a/testing.go
+++ b/testing.go
@@ -137,7 +137,7 @@ func (test *Test) Context() context.Context {
 	return test.ctx
 }
 
-// Runs a child test
+// Runs a sub test
 func (test *Test) Run(name string, f func(t *testing.T)) {
 	pc, _, _, _ := runtime.Caller(1)
 	test.t.Run(name, func(childT *testing.T) {

--- a/testing.go
+++ b/testing.go
@@ -36,17 +36,20 @@ type stdIO struct {
 	sync      *sync.WaitGroup
 }
 
+// Instrument a test
 func InstrumentTest(t *testing.T, f func(ctx context.Context, t *testing.T)) {
 	test := StartTest(t)
 	defer test.End()
 	f(test.Context(), t)
 }
 
+// Starts a new test
 func StartTest(t *testing.T) *Test {
 	pc, _, _, _ := runtime.Caller(1)
 	return startTestFromCaller(t, pc)
 }
 
+// Starts a new test with and uses the caller pc info for Name and Suite
 func startTestFromCaller(t *testing.T, pc uintptr) *Test {
 	fullTestName := t.Name()
 	testNameSlash := strings.IndexByte(fullTestName, '/')
@@ -105,6 +108,7 @@ func startTestFromCaller(t *testing.T, pc uintptr) *Test {
 	return test
 }
 
+// Ends the current test
 func (test *Test) End() {
 	if r := recover(); r != nil {
 		test.span.SetTag("test.status", "ERROR")
@@ -158,6 +162,7 @@ func (test *Test) End() {
 	test.span.Finish()
 }
 
+// Gets the test context
 func (test *Test) Context() context.Context {
 	return test.ctx
 }


### PR DESCRIPTION
Closes #44 

This PR contains fixes to support Subtests, this fixes are related to:
- Test source code span tag
- Test name span tag
- Test suite span tag

Also adds support for a custom `Run` func.

Example:

```go

func TestMain(m *testing.M) {
	result := m.Run()
	GlobalAgent.Stop()
	os.Exit(result)
}

func TestWithChildren(t *testing.T) {

	t.Run("child01", func (ti *testing.T){
		test := StartTest(ti)
		defer test.End()
		fmt.Println("Child Test 01")

	})

	t.Run("child02", func (ti *testing.T){
		test := StartTest(ti)
		defer test.End()
		fmt.Println("Child Test 02")

		ti.Run("OtherChild", func(ti2 *testing.T){
			test2 := StartTest(ti2)
			defer test2.End()
			fmt.Println("Child Test 02 / Other child")
		})

	})

}

func TestChildRun(t *testing.T) {
	test := StartTest(t)
	defer test.End()

	var tests = []struct {
		os string
	}{
		{os: "windows"}, {os: "darwin"}, {os: "linux"},
	}

	for _, tt := range tests {
		test.Run(tt.os, func(t *testing.T) {

		})
	}
}
```

Scope:

![image](https://user-images.githubusercontent.com/69803/64608590-4e7ac000-d3cb-11e9-969f-b075d28a4eeb.png)

![image](https://user-images.githubusercontent.com/69803/64608620-5fc3cc80-d3cb-11e9-9142-a84c04c29fd0.png)
