### PR TITLE
sync.Once is not required in init() func

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -32,25 +32,22 @@ var (
 
 	version = "0.1.0-dev"
 
-	once        sync.Once
 	gitDataOnce sync.Once
 	gitData     *GitData
 )
 
 func init() {
-	once.Do(func() {
-		GlobalAgent = NewAgent()
+	GlobalAgent = NewAgent()
 
-		if getBoolEnv("SCOPE_SET_GLOBAL_TRACER", true) {
-			opentracing.SetGlobalTracer(GlobalAgent.Tracer)
-		}
+	if getBoolEnv("SCOPE_SET_GLOBAL_TRACER", true) {
+		opentracing.SetGlobalTracer(GlobalAgent.Tracer)
+	}
 
-		if getBoolEnv("SCOPE_AUTO_INSTRUMENT", true) {
-			if err := PatchAll(); err != nil {
-				panic(err)
-			}
+	if getBoolEnv("SCOPE_AUTO_INSTRUMENT", true) {
+		if err := PatchAll(); err != nil {
+			panic(err)
 		}
-	})
+	}
 }
 
 func NewAgent() *Agent {

--- a/ntp/clock.go
+++ b/ntp/clock.go
@@ -3,7 +3,6 @@ package ntp
 import (
 	"fmt"
 	"github.com/beevik/ntp"
-	"sync"
 	"time"
 )
 
@@ -13,32 +12,29 @@ const (
 
 var (
 	ntpOffset     time.Duration
-	ntpOffsetOnce sync.Once
 )
 
 func init() {
-	ntpOffsetOnce.Do(func() {
-		tries := 3
-		var response *ntp.Response
-		for {
-			if tries > 0 {
-				tries--
-				r, err := ntp.Query(Server)
-				if err != nil {
-					fmt.Printf("%v\n", err)
-					time.Sleep(1 * time.Second)
-					continue
-				}
-				response = r
+	tries := 3
+	var response *ntp.Response
+	for {
+		if tries > 0 {
+			tries--
+			r, err := ntp.Query(Server)
+			if err != nil {
+				fmt.Printf("%v\n", err)
+				time.Sleep(1 * time.Second)
+				continue
 			}
-			break
+			response = r
 		}
-		if response != nil {
-			ntpOffset = response.ClockOffset
-		} else {
-			fmt.Println("Error getting the NTP offset")
-		}
-	})
+		break
+	}
+	if response != nil {
+		ntpOffset = response.ClockOffset
+	} else {
+		fmt.Println("Error getting the NTP offset")
+	}
 }
 
 // Returns the time.Now() with the ntp offset


### PR DESCRIPTION
This `PR` removes all `sync.Once` usages from the `init()` functions.

According the [Golang specification](https://golang.org/ref/spec#Package_initialization) an `init()` function:

> If a package has imports, the imported packages are initialized before initializing the package itself. If multiple packages import a package, **the imported package will be initialized only once**.

also:

> **Package initialization—variable initialization and the invocation of init functions—happens in a single goroutine, sequentially, one package at a time.**

This means the `init()` function is guaranteed to be called once and thread safe, so, there is not need to use the `sync.Once` object.