### PR TITLE
Add windows path support

### DIFF
--- a/instrumentation/testing/logging.go
+++ b/instrumentation/testing/logging.go
@@ -22,7 +22,7 @@ type stdIO struct {
 	sync      *sync.WaitGroup
 }
 
-var LOG_REGEX_TEMPLATE = `^%s(?:(?P<date>\d{4}\/\d{1,2}\/\d{1,2}) )?(?:(?P<time>\d{1,2}:\d{1,2}:\d{1,2}(?:.\d{1,6})?) )?(?:(?:(?P<file>[\w\-. \/\\:]+):(?P<line>\d+)): )?(.*)\n?$`
+var LOG_REGEX_TEMPLATE = `^%s(?:(?P<date>\d{4}\/\d{1,2}\/\d{1,2}) )?(?:(?P<time>\d{1,2}:\d{1,2}:\d{1,2}(?:.\d{1,6})?) )?(?:(?:(?P<file>[\w\-. /\\:]+):(?P<line>\d+)): )?(.*)\n?$`
 
 func (test *Test) startCapturingLogs() {
 	// Replaces stdout and stderr

--- a/instrumentation/testing/logging.go
+++ b/instrumentation/testing/logging.go
@@ -22,7 +22,7 @@ type stdIO struct {
 	sync      *sync.WaitGroup
 }
 
-var LOG_REGEX_TEMPLATE = `^%s(?:(?P<date>\d{4}\/\d{1,2}\/\d{1,2}) )?(?:(?P<time>\d{1,2}:\d{1,2}:\d{1,2}(?:.\d{1,6})?) )?(?:(?:(?P<file>[\w\-. /]+):(?P<line>\d+)): )?(.*)\n?$`
+var LOG_REGEX_TEMPLATE = `^%s(?:(?P<date>\d{4}\/\d{1,2}\/\d{1,2}) )?(?:(?P<time>\d{1,2}:\d{1,2}:\d{1,2}(?:.\d{1,6})?) )?(?:(?:(?P<file>[\w\-. \/\\:]+):(?P<line>\d+)): )?(.*)\n?$`
 
 func (test *Test) startCapturingLogs() {
 	// Replaces stdout and stderr

--- a/instrumentation/testing/logging_test.go
+++ b/instrumentation/testing/logging_test.go
@@ -1,0 +1,53 @@
+package testing
+
+import (
+	"fmt"
+	stdlog "log"
+	"regexp"
+	goTest "testing"
+)
+
+func TestLoggingRegex(t *goTest.T) {
+	re := regexp.MustCompile(fmt.Sprintf(LOG_REGEX_TEMPLATE, stdlog.Prefix()))
+
+	var loglines = [][]string{
+		{"2009/01/23 01:23:23.123123 /a/b/c/d.go:23: message", "2009/01/23", "01:23:23.123123", "/a/b/c/d.go", "23", "message"},
+		{"2009/01/23 01:23:23 /a/b/c/d.go:23: message", "2009/01/23", "01:23:23", "/a/b/c/d.go", "23", "message"},
+		{"2009/01/23 /a/b/c/d.go:23: message", "2009/01/23", "", "/a/b/c/d.go", "23", "message"},
+		{"/a/b/c/d.go:23: message", "", "", "/a/b/c/d.go", "23", "message"},
+
+		{"2009/01/23 01:23:23.123123 d.go:23: message", "2009/01/23", "01:23:23.123123", "d.go", "23", "message"},
+		{"2009/01/23 01:23:23 d.go:23: message", "2009/01/23", "01:23:23", "d.go", "23", "message"},
+		{"2009/01/23 d.go:23: message", "2009/01/23", "", "d.go", "23", "message"},
+		{"d.go:23: message", "", "", "d.go", "23", "message"},
+
+		{"2009/01/23 01:23:23.123123 message", "2009/01/23", "01:23:23.123123", "", "", "message"},
+		{"2009/01/23 01:23:23 message", "2009/01/23", "01:23:23", "", "", "message"},
+		{"2009/01/23 message", "2009/01/23", "", "", "", "message"},
+		{"message", "", "", "", "", "message"},
+
+		{"2009/01/23 01:23:23.123123 c:/a/b/c/d.go:23: message", "2009/01/23", "01:23:23.123123", "c:/a/b/c/d.go", "23", "message"},
+		{"2009/01/23 01:23:23 c:/a/b/c/d.go:23: message", "2009/01/23", "01:23:23", "c:/a/b/c/d.go", "23", "message"},
+		{"2009/01/23 c:/a/b/c/d.go:23: message", "2009/01/23", "", "c:/a/b/c/d.go", "23", "message"},
+		{"c:/a/b/c/d.go:23: message", "", "", "c:/a/b/c/d.go", "23", "message"},
+
+
+		{"2009/01/23 01:23:23.123123 c:\\a\\b\\c\\d.go:23: message", "2009/01/23", "01:23:23.123123", "c:\\a\\b\\c\\d.go", "23", "message"},
+		{"2009/01/23 01:23:23 c:\\a\\b\\c\\d.go:23: message", "2009/01/23", "01:23:23", "c:\\a\\b\\c\\d.go", "23", "message"},
+		{"2009/01/23 c:\\a\\b\\c\\d.go:23: message", "2009/01/23", "", "c:\\a\\b\\c\\d.go", "23", "message"},
+		{"c:\\a\\b\\c\\d.go:23: message", "", "", "c:\\a\\b\\c\\d.go", "23", "message"},
+	}
+
+	for i := 0; i < len(loglines); i++ {
+		logline := loglines[i]
+		t.Run(fmt.Sprintf("Value %v", i), func(st *goTest.T) {
+			matches := re.FindStringSubmatch(logline[0])
+
+			for idx := 0; idx <= 5; idx ++ {
+				if matches[idx] != logline[idx] {
+					t.Fatalf("Error in line[%v]: %v. Value expected: %v, Actual value: %v", i, logline[0], logline[idx], matches[idx])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #69 

This PR modifies the `regex` in the logging instrumentation to add support to windows paths.

![image](https://user-images.githubusercontent.com/69803/67307125-48aee900-f4f8-11e9-9756-a776e72b7b06.png)
