### PR TITLE
Http client and server payload instrumentation

### DIFF
--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -243,7 +243,8 @@ func getResponsePayload(resp *http.Response, bufferSize int) string {
 	var rsPayLoad string
 	if resp.Body != nil {
 		rsBodyBuffer := make([]byte, bufferSize)
-		if len, err := resp.Body.Read(rsBodyBuffer); err == nil {
+		len, _ := resp.Body.Read(rsBodyBuffer)
+		if len > 0 {
 			if len < bufferSize {
 				rsBodyBuffer = rsBodyBuffer[:len]
 			}

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -222,7 +222,7 @@ func (t *Transport) doRoundTrip(req *http.Request) (*http.Response, error) {
 // Gets the request payload
 func getRequestPayload(req *http.Request, bufferSize int) string {
 	var rqPayload string
-	if req.Body != nil {
+	if req.Body != nil && req.Body != http.NoBody {
 		rqBody, rqErr := req.GetBody()
 		if rqErr == nil {
 			rqBodyBuffer := make([]byte, bufferSize)
@@ -241,7 +241,7 @@ func getRequestPayload(req *http.Request, bufferSize int) string {
 // Gets the response payload
 func getResponsePayload(resp *http.Response, bufferSize int) string {
 	var rsPayload string
-	if resp.Body != nil {
+	if resp.Body != nil && resp.Body != http.NoBody {
 		rsBodyBuffer := make([]byte, bufferSize)
 		len, _ := resp.Body.Read(rsBodyBuffer)
 		if len > 0 {

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -187,7 +187,7 @@ func (t *Transport) doRoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if t.PayloadInstrumentation {
-		rqPayload := getRequestPayload(req, 512)
+		rqPayload := getRequestPayload(req, payloadBufferSize)
 		tracer.sp.SetTag("http.request_payload", rqPayload)
 	} else {
 		tracer.sp.SetTag("http.request_payload.unavailable", "disabled")
@@ -196,7 +196,7 @@ func (t *Transport) doRoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := rt.RoundTrip(req)
 
 	if t.PayloadInstrumentation {
-		rsPayLoad := getResponsePayload(resp, 512)
+		rsPayLoad := getResponsePayload(resp, payloadBufferSize)
 		tracer.sp.SetTag("http.response_payload", rsPayLoad)
 	} else {
 		tracer.sp.SetTag("http.response_payload.unavailable", "disabled")

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -3,16 +3,18 @@ package nethttp
 import (
 	"bytes"
 	"context"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/log"
-	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptrace"
 	"strconv"
 	"strings"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+
+	"go.undefinedlabs.com/scopeagent/instrumentation"
 )
 
 type contextKey int

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -240,7 +240,7 @@ func getRequestPayload(req *http.Request, bufferSize int) string {
 
 // Gets the response payload
 func getResponsePayload(resp *http.Response, bufferSize int) string {
-	var rsPayLoad string
+	var rsPayload string
 	if resp.Body != nil {
 		rsBodyBuffer := make([]byte, bufferSize)
 		len, _ := resp.Body.Read(rsBodyBuffer)
@@ -249,7 +249,7 @@ func getResponsePayload(resp *http.Response, bufferSize int) string {
 				rsBodyBuffer = rsBodyBuffer[:len]
 			}
 			rsRunes := bytes.Runes(rsBodyBuffer)
-			rsPayLoad = string(rsRunes)
+			rsPayload = string(rsRunes)
 			resp.Body = struct {
 				io.Reader
 				io.Closer
@@ -259,7 +259,7 @@ func getResponsePayload(resp *http.Response, bufferSize int) string {
 			}
 		}
 	}
-	return rsPayLoad
+	return rsPayload
 }
 
 // Tracer holds tracing details for one HTTP request.

--- a/instrumentation/nethttp/patch.go
+++ b/instrumentation/nethttp/patch.go
@@ -12,3 +12,12 @@ func PatchHttpDefaultClient() {
 		http.DefaultClient = &http.Client{Transport: &Transport{RoundTripper: http.DefaultTransport}}
 	})
 }
+
+func PatchHttpDefaultClientWithPayload() {
+	once.Do(func() {
+		http.DefaultClient = &http.Client{Transport: &Transport{
+			RoundTripper:           http.DefaultTransport,
+			PayloadInstrumentation: true,
+		}}
+	})
+}

--- a/instrumentation/nethttp/patch.go
+++ b/instrumentation/nethttp/patch.go
@@ -5,19 +5,24 @@ import (
 	"sync"
 )
 
+type Option func(*Transport)
+
 var once sync.Once
 
-func PatchHttpDefaultClient() {
-	once.Do(func() {
-		http.DefaultClient = &http.Client{Transport: &Transport{RoundTripper: http.DefaultTransport}}
-	})
+// Enables the payload instrumentation in the transport
+func WithPayloadInstrumentation() Option {
+	return func(t *Transport) {
+		t.PayloadInstrumentation = true
+	}
 }
 
-func PatchHttpDefaultClientWithPayload() {
+// Patches the default http client with the instrumented transport
+func PatchHttpDefaultClient(options ...Option) {
 	once.Do(func() {
-		http.DefaultClient = &http.Client{Transport: &Transport{
-			RoundTripper:           http.DefaultTransport,
-			PayloadInstrumentation: true,
-		}}
+		transport := &Transport{RoundTripper: http.DefaultTransport}
+		for _, option := range options {
+			option(transport)
+		}
+		http.DefaultClient = &http.Client{Transport: transport}
 	})
 }

--- a/instrumentation/nethttp/responseTracker.go
+++ b/instrumentation/nethttp/responseTracker.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-type statusCodeTracker struct {
+type responseTracker struct {
 	http.ResponseWriter
 	status                 int
 	wroteheader            bool
@@ -15,13 +15,13 @@ type statusCodeTracker struct {
 
 var payloadBufferSize = 512
 
-func (w *statusCodeTracker) WriteHeader(status int) {
+func (w *responseTracker) WriteHeader(status int) {
 	w.status = status
 	w.wroteheader = true
 	w.ResponseWriter.WriteHeader(status)
 }
 
-func (w *statusCodeTracker) Write(b []byte) (int, error) {
+func (w *responseTracker) Write(b []byte) (int, error) {
 	if !w.wroteheader {
 		w.wroteheader = true
 		w.status = 200
@@ -44,7 +44,7 @@ func (w *statusCodeTracker) Write(b []byte) (int, error) {
 // ResponseWriter and only implements the same combination of additional
 // interfaces as the original.  This implementation is based on
 // https://github.com/felixge/httpsnoop.
-func (w *statusCodeTracker) wrappedResponseWriter() http.ResponseWriter {
+func (w *responseTracker) wrappedResponseWriter() http.ResponseWriter {
 	var (
 		hj, i0 = w.ResponseWriter.(http.Hijacker)
 		cn, i1 = w.ResponseWriter.(http.CloseNotifier)

--- a/instrumentation/nethttp/server.go
+++ b/instrumentation/nethttp/server.go
@@ -109,7 +109,7 @@ func middleware(tr opentracing.Tracer, h http.Handler, options ...MWOption) http
 func middlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOption) http.HandlerFunc {
 	opts := mwOptions{
 		opNameFunc: func(r *http.Request) string {
-			return "SERVER HTTP " + r.Method
+			return "HTTP " + r.Method
 		},
 		spanFilter:   func(r *http.Request) bool { return true },
 		spanObserver: func(span opentracing.Span, r *http.Request) {},

--- a/instrumentation/nethttp/server.go
+++ b/instrumentation/nethttp/server.go
@@ -155,6 +155,13 @@ func middlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		sct.payloadInstrumentation = opts.payloadInstrumentation
 		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
 
+		if opts.payloadInstrumentation {
+			rqPayload := getRequestPayload(r, payloadBufferSize)
+			sp.SetTag("http.request_payload", rqPayload)
+		} else {
+			sp.SetTag("http.request_payload.unavailable", "disabled")
+		}
+
 		defer func() {
 			ext.HTTPStatusCode.Set(sp, uint16(sct.status))
 			if sct.status >= http.StatusBadRequest || !sct.wroteheader {

--- a/instrumentation/nethttp/server.go
+++ b/instrumentation/nethttp/server.go
@@ -155,18 +155,19 @@ func middlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 		sct.payloadInstrumentation = opts.payloadInstrumentation
 		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
 
-		if opts.payloadInstrumentation {
-			rqPayload := getRequestPayload(r, payloadBufferSize)
-			sp.SetTag("http.request_payload", rqPayload)
-		} else {
-			sp.SetTag("http.request_payload.unavailable", "disabled")
-		}
-
 		defer func() {
 			ext.HTTPStatusCode.Set(sp, uint16(sct.status))
 			if sct.status >= http.StatusBadRequest || !sct.wroteheader {
 				ext.Error.Set(sp, true)
 			}
+
+			if sct.payloadInstrumentation {
+				rqPayload := getRequestPayload(r, payloadBufferSize)
+				sp.SetTag("http.request_payload", rqPayload)
+			} else {
+				sp.SetTag("http.request_payload.unavailable", "disabled")
+			}
+
 			if sct.payloadInstrumentation {
 				rsRunes := bytes.Runes(sct.payloadBuffer)
 				rsPayload := string(rsRunes)


### PR DESCRIPTION
This `PR` adds http payload instrumentation in both `client` and `server`.

*This instrumentation is optional, so must be configured like this:*

**On client side, changing:**
```go
func TestMain(m *testing.M) {
	nethttp.PatchHttpDefaultClient()
	os.Exit(scopeagent.Run(m, agent.WithSetGlobalTracer()))
}
```
**to:**
```go
func TestMain(m *testing.M) {
	nethttp.PatchHttpDefaultClientWithPayload()
	os.Exit(scopeagent.Run(m, agent.WithSetGlobalTracer()))
}
```

**On server side, changing:**
```go
func main() {
    // Make sure the agent is installed first
    scopeAgent, err := agent.NewAgent()
    if err != nil {
        panic(err)
    }
    defer scopeAgent.Stop()

    http.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
        io.WriteString(w, "Hello, world!\n")
    })
    
    err := http.ListenAndServe(":8080", nethttp.Middleware(nil))
    if err != nil {
        panic(err)
    }
}
```
**to:**
```go
func main() {
    // Make sure the agent is installed first
    scopeAgent, err := agent.NewAgent()
    if err != nil {
        panic(err)
    }
    defer scopeAgent.Stop()

    http.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
        io.WriteString(w, "Hello, world!\n")
    })
    
    err := http.ListenAndServe(":8080", nethttp.Middleware(nil, nethttp.MWPayloadInstrumentation()))
    if err != nil {
        panic(err)
    }
}
```

**Example:** https://shared.scope.dev/dashboard/8cee2622-8772-4338-8d72-63653e0e0239/66857b5a-cd46-4b9a-a6b3-438a51b84b4b/default/explore/inspect/0d41c72a364770ed4a12a7beccf6bfab4c3d3a30/00000000-0000-0000-06e8-fe9096dc6331/trace?spanId=00000000-0000-0000-44fb-62b2f10a7980