### PR TITLE
Adds retry support

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -155,10 +155,15 @@ func WithConfiguration(values map[string]interface{}) Option {
 	}
 }
 
-func WithRetriesOnFail(retriesCount int, exitOnError bool) Option {
+func WithRetriesOnFail(retriesCount int) Option {
 	return func(agent *Agent) {
 		agent.failRetriesCount = retriesCount
-		agent.exitOnError = exitOnError
+	}
+}
+
+func WithHandlePanicAsFail() Option {
+	return func(agent *Agent) {
+		agent.exitOnError = true
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -333,7 +333,7 @@ func (a *Agent) Logger() *log.Logger {
 func (a *Agent) Run(m *testing.M) int {
 	defer a.Stop()
 	if !a.exitOnError || a.failRetriesCount > 0 {
-		return runner.Run(m, a.exitOnError, a.failRetriesCount)
+		return runner.Run(m, a.exitOnError, a.failRetriesCount, a.logger)
 	}
 	return m.Run()
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,6 +20,7 @@ import (
 
 	scopeError "go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	"go.undefinedlabs.com/scopeagent/runner"
 	"go.undefinedlabs.com/scopeagent/tags"
 	"go.undefinedlabs.com/scopeagent/tracer"
 )
@@ -30,12 +32,14 @@ type (
 		apiEndpoint string
 		apiKey      string
 
-		agentId         string
-		version         string
-		metadata        map[string]interface{}
-		debugMode       bool
-		testingMode     bool
-		setGlobalTracer bool
+		agentId          string
+		version          string
+		metadata         map[string]interface{}
+		debugMode        bool
+		testingMode      bool
+		setGlobalTracer  bool
+		exitOnError      bool
+		failRetriesCount int
 
 		recorder         *SpanRecorder
 		recorderFilename string
@@ -151,6 +155,13 @@ func WithConfiguration(values map[string]interface{}) Option {
 	}
 }
 
+func WithRetriesOnFail(retriesCount int, exitOnError bool) Option {
+	return func(agent *Agent) {
+		agent.failRetriesCount = retriesCount
+		agent.exitOnError = exitOnError
+	}
+}
+
 // Creates a new Scope Agent instance
 func NewAgent(options ...Option) (*Agent, error) {
 	agent := new(Agent)
@@ -158,6 +169,8 @@ func NewAgent(options ...Option) (*Agent, error) {
 	agent.version = version
 	agent.agentId = generateAgentID()
 	agent.userAgent = fmt.Sprintf("scope-agent-go/%s", agent.version)
+	agent.exitOnError = true
+	agent.failRetriesCount = 0
 
 	for _, opt := range options {
 		opt(agent)
@@ -309,6 +322,15 @@ func (a *Agent) Tracer() opentracing.Tracer {
 
 func (a *Agent) Logger() *log.Logger {
 	return a.logger
+}
+
+// Runs the test suite
+func (a *Agent) Run(m *testing.M) int {
+	defer a.Stop()
+	if !a.exitOnError || a.failRetriesCount > 0 {
+		return runner.Run(m, a.exitOnError, a.failRetriesCount)
+	}
+	return m.Run()
 }
 
 // Stops the agent

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -163,7 +163,7 @@ func WithRetriesOnFail(retriesCount int) Option {
 
 func WithHandlePanicAsFail() Option {
 	return func(agent *Agent) {
-		agent.exitOnError = true
+		agent.exitOnError = false
 	}
 }
 

--- a/init.go
+++ b/init.go
@@ -2,11 +2,12 @@ package scopeagent // import "go.undefinedlabs.com/scopeagent"
 
 import (
 	"context"
+	"runtime"
+	"testing"
+
 	"go.undefinedlabs.com/scopeagent/agent"
 	"go.undefinedlabs.com/scopeagent/instrumentation/logging"
 	scopetesting "go.undefinedlabs.com/scopeagent/instrumentation/testing"
-	"runtime"
-	"testing"
 )
 
 var defaultAgent *agent.Agent
@@ -31,7 +32,7 @@ func Run(m *testing.M, opts ...agent.Option) int {
 
 	defer newAgent.Stop()
 	defaultAgent = newAgent
-	return m.Run()
+	return newAgent.Run(m)
 }
 
 // Instruments the given test, returning a `Test` object that can be used to extend the test trace

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -101,7 +101,7 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 
 	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
 	// to search the func source code bounds and to calculate the package name.
-	fullTestName := runner.GetTestName(b.Name())
+	fullTestName := runner.GetOriginalTestName(b.Name())
 
 	// We detect if the parent benchmark is instrumented, and if so we remove the "*" SubBenchmark from the previous instrumentation
 	parentBenchmark := getParentBenchmark(b)

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdErrors "errors"
 	"fmt"
+	"go.undefinedlabs.com/scopeagent/runner"
 	"math"
 	"reflect"
 	"regexp"
@@ -100,7 +101,7 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 
 	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
 	// to search the func source code bounds and to calculate the package name.
-	fullTestName := b.Name()
+	fullTestName := runner.GetTestName(b.Name())
 
 	// We detect if the parent benchmark is instrumented, and if so we remove the "*" SubBenchmark from the previous instrumentation
 	parentBenchmark := getParentBenchmark(b)

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -2,22 +2,20 @@ package testing
 
 import (
 	"context"
-	stdErrors "errors"
 	"fmt"
 	"math"
-	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/opentracing/opentracing-go"
 
 	"go.undefinedlabs.com/scopeagent/ast"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	"go.undefinedlabs.com/scopeagent/reflection"
 	"go.undefinedlabs.com/scopeagent/runner"
 )
 
@@ -157,42 +155,31 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 }
 
 func getParentBenchmark(b *testing.B) *testing.B {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("parent")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return *(**testing.B)(ptrToY)
+	if ptr, err := reflection.GetFieldPointerOfB(b, "parent"); err == nil {
+		return *(**testing.B)(ptr)
 	}
 	return nil
 }
 
 func getBenchmarkSuiteName(b *testing.B) string {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("importPath")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return *(*string)(ptrToY)
+	if ptr, err := reflection.GetFieldPointerOfB(b, "importPath"); err == nil {
+		return *(*string)(ptr)
 	}
 	return ""
 }
 
 func getBenchmarkHasSub(b *testing.B) int32 {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("hasSub")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return *(*int32)(ptrToY)
+	if ptr, err := reflection.GetFieldPointerOfB(b, "hasSub"); err == nil {
+		return *(*int32)(ptr)
 	}
 	return 0
 }
 
 //Extract benchmark result from the private result field in testing.B
 func extractBenchmarkResult(b *testing.B) (*testing.BenchmarkResult, error) {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("result")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return (*testing.BenchmarkResult)(ptrToY), nil
+	if ptr, err := reflection.GetFieldPointerOfB(b, "result"); err == nil {
+		return (*testing.BenchmarkResult)(ptr), nil
+	} else {
+		return nil, err
 	}
-	return nil, stdErrors.New("result can't be retrieved")
 }

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	stdErrors "errors"
 	"fmt"
-	"go.undefinedlabs.com/scopeagent/runner"
 	"math"
 	"reflect"
 	"regexp"
@@ -19,6 +18,7 @@ import (
 
 	"go.undefinedlabs.com/scopeagent/ast"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	"go.undefinedlabs.com/scopeagent/runner"
 )
 
 type (

--- a/instrumentation/testing/init.go
+++ b/instrumentation/testing/init.go
@@ -1,18 +1,18 @@
 package testing
 
 import (
-	stdErrors "errors"
 	"os"
 	"reflect"
 	"testing"
-	"unsafe"
 
 	"github.com/undefinedlabs/go-mpatch"
+
+	"go.undefinedlabs.com/scopeagent/reflection"
 )
 
 // Initialize the testing instrumentation
 func Init(m *testing.M) {
-	if tPointer, err := getFieldPointerOfM(m, "tests"); err == nil {
+	if tPointer, err := reflection.GetFieldPointerOfM(m, "tests"); err == nil {
 		intTests := (*[]testing.InternalTest)(tPointer)
 		tests := make([]testing.InternalTest, 0)
 		for _, test := range *intTests {
@@ -31,7 +31,7 @@ func Init(m *testing.M) {
 		// Replace internal tests with new test indirection
 		*intTests = tests
 	}
-	if bPointer, err := getFieldPointerOfM(m, "benchmarks"); err == nil {
+	if bPointer, err := reflection.GetFieldPointerOfM(m, "benchmarks"); err == nil {
 		intBenchmarks := (*[]testing.InternalBenchmark)(bPointer)
 		var benchmarks []testing.InternalBenchmark
 		for _, benchmark := range *intBenchmarks {
@@ -65,15 +65,4 @@ func Init(m *testing.M) {
 			logOnError(err)
 		}
 	}
-}
-
-// Gets a private field from the testing.M struct using reflection
-func getFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) {
-	val := reflect.Indirect(reflect.ValueOf(m))
-	member := val.FieldByName(fieldName)
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return ptrToY, nil
-	}
-	return nil, stdErrors.New("field can't be retrieved")
 }

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -18,6 +18,7 @@ import (
 	"go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/instrumentation/logging"
+	"go.undefinedlabs.com/scopeagent/runner"
 	"go.undefinedlabs.com/scopeagent/tags"
 )
 
@@ -80,7 +81,7 @@ func StartTestFromCaller(t *testing.T, pc uintptr, opts ...Option) *Test {
 
 	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
 	// to search the func source code bounds and to calculate the package name.
-	fullTestName := t.Name()
+	fullTestName := runner.GetTestName(t.Name())
 	testNameSlash := strings.IndexByte(fullTestName, '/')
 	funcName := fullTestName
 	if testNameSlash >= 0 {
@@ -114,7 +115,7 @@ func StartTestFromCaller(t *testing.T, pc uintptr, opts ...Option) *Test {
 		test.ctx = context.Background()
 	}
 
-	span, ctx := opentracing.StartSpanFromContextWithTracer(test.ctx, instrumentation.Tracer(), t.Name(), startOptions...)
+	span, ctx := opentracing.StartSpanFromContextWithTracer(test.ctx, instrumentation.Tracer(), fullTestName, startOptions...)
 	span.SetBaggageItem("trace.kind", "test")
 	test.span = span
 	test.ctx = ctx

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -81,7 +81,7 @@ func StartTestFromCaller(t *testing.T, pc uintptr, opts ...Option) *Test {
 
 	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
 	// to search the func source code bounds and to calculate the package name.
-	fullTestName := runner.GetTestName(t.Name())
+	fullTestName := runner.GetOriginalTestName(t.Name())
 	testNameSlash := strings.IndexByte(fullTestName, '/')
 	funcName := fullTestName
 	if testNameSlash >= 0 {

--- a/reflection/reflect.go
+++ b/reflection/reflect.go
@@ -1,0 +1,30 @@
+package reflection
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// Gets a pointer of a private or public field in a testing.M struct
+func GetFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(m))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, errors.New("field can't be retrieved")
+}
+
+// Gets a pointer of a private or public field in a testing.T struct
+func GetFieldPointerOfT(t *testing.T, fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(t))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, errors.New("field can't be retrieved")
+}

--- a/reflection/reflect.go
+++ b/reflection/reflect.go
@@ -28,3 +28,14 @@ func GetFieldPointerOfT(t *testing.T, fieldName string) (unsafe.Pointer, error) 
 	}
 	return nil, errors.New("field can't be retrieved")
 }
+
+// Gets a pointer of a private or public field in a testing.B struct
+func GetFieldPointerOfB(b *testing.B, fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(b))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, errors.New("result can't be retrieved")
+}

--- a/runner/main.go
+++ b/runner/main.go
@@ -2,12 +2,13 @@ package runner
 
 import (
 	"errors"
-	"fmt"
+	"io/ioutil"
+	"log"
 	"reflect"
 	"regexp"
 	"strconv"
+	"sync"
 	"testing"
-	"time"
 	"unsafe"
 )
 
@@ -16,6 +17,9 @@ type (
 		m                *testing.M
 		failRetriesCount int
 		exitOnError      bool
+		logger           *log.Logger
+		failed           bool
+		failedlock       *sync.Mutex
 	}
 	testDescriptor struct {
 		runner  *testRunner
@@ -26,31 +30,35 @@ type (
 		error   bool
 		skipped bool
 	}
-	internalTestResult struct {
-		ran        bool      // Test or benchmark (or one of its subtests) was executed.
-		failed     bool      // Test or benchmark has failed.
-		skipped    bool      // Test of benchmark has been skipped.
-		done       bool      // Test is finished and all subtests have completed.
-		finished   bool      // Test function has completed.
-		raceErrors int       // number of races detected during test
-		name       string    // Name of test or benchmark.
-		start      time.Time // Time test or benchmark started
-		duration   time.Duration
-	}
 )
 
 var runner *testRunner
-var runnerRegexName *regexp.Regexp
+var runnerRegexName = regexp.MustCompile(`(?m)([\w -:_]*)\/\[runner.[\w:]*]\/\[group](\/[\w -:_]*)?`)
+
+// Gets the test name
+func GetOriginalTestName(name string) string {
+	match := runnerRegexName.FindStringSubmatch(name)
+	if match == nil || len(match) == 0 {
+		return name
+	}
+	return match[1] + match[2]
+}
 
 // Runs a test suite
-func Run(m *testing.M, exitOnError bool, failRetriesCount int) int {
+func Run(m *testing.M, exitOnError bool, failRetriesCount int, logger *log.Logger) int {
+	if logger == nil {
+		logger = log.New(ioutil.Discard, "", 0)
+	}
 	runner := &testRunner{
 		m:                m,
 		exitOnError:      exitOnError,
 		failRetriesCount: failRetriesCount,
+		logger:           logger,
+		failed:           false,
+		failedlock:       &sync.Mutex{},
 	}
 	runner.init()
-	return runner.Run()
+	return runner.m.Run()
 }
 
 // Initialize test runner, replace the internal test with an indirection
@@ -75,11 +83,6 @@ func (r *testRunner) init() {
 	}
 }
 
-// Runs the test suite
-func (r *testRunner) Run() int {
-	return r.m.Run()
-}
-
 // Internal test runner, each test calls this method in order to handle retries and process exiting
 func (td *testDescriptor) run(t *testing.T) {
 	run := 1
@@ -95,83 +98,89 @@ func (td *testDescriptor) run(t *testing.T) {
 		}
 		title = "[runner." + title + "]"
 		t.Run(title, func(it *testing.T) {
-			defer func() {
-				rc = recover()
-				if rc != nil {
-					it.FailNow()
-				}
-			}()
-			innerTest = it
-			td.test.F(it)
+			// We need to run another subtest in order to support t.Parallel()
+			// https://stackoverflow.com/a/53950628
+			it.Run("[group]", func(gt *testing.T) {
+				defer func() {
+					rc = recover()
+					if rc != nil {
+						gt.FailNow()
+					}
+				}()
+				innerTest = gt
+				td.test.F(gt)
+			})
 		})
-		innerTestInfo := getTestResultsInfo(innerTest)
-
 		if rc != nil {
 			if exitOnError {
 				panic(rc)
 			}
-			fmt.Println("PANIC RECOVER:", rc)
+			td.runner.logger.Println("PANIC RECOVER:", rc)
 			td.error = true
 		}
-		td.skipped = innerTestInfo.skipped
+		td.skipped = innerTest.Skipped()
+		if td.skipped {
+			t.SkipNow()
+			break
+		}
 		td.ran++
 
-		// Current run failure
-		if innerTestInfo.failed {
+		if innerTest.Failed() {
+			// Current run failure
 			td.failed = true
-		}
-		// Current run ok but previous with fail -> Flaky
-		if !innerTestInfo.failed && td.failed {
+		} else if td.failed {
+			// Current run ok but previous run with fail -> Flaky
 			td.failed = false
 			td.flaky = true
+			td.runner.logger.Println("FLAKY TEST DETECTED:", t.Name())
+			break
+		} else {
+			// Current run ok and previous run (if any) not marked as failed
 			break
 		}
 
-		if td.skipped || !td.failed || run > maxRetries {
+		if run > maxRetries {
 			break
 		}
 		run++
 	}
-	if td.flaky {
-		fmt.Println("*** FLAKY", t.Name())
-	}
+
+	// Set the global failed flag
+	td.runner.failedlock.Lock()
+	td.runner.failed = td.runner.failed || td.failed || td.error
+	setTestFailureFlag(getTestParent(t), td.runner.failed)
+	td.runner.failedlock.Unlock()
+
 	if td.error && exitOnError {
+		// If after all recovers and retries the test finish with error and we have the exitOnError flag,
+		// we panic with the latest recovered data
 		panic(rc)
 	}
 	if !td.error && !td.failed {
-		removeTestFailureFlag(t)
+		// If test pass or flaky
+		setTestFailureFlag(t, false)
 	}
 }
 
-// Gets the test name
-func GetOriginalTestName(name string) string {
-	if runnerRegexName == nil {
-		runnerRegexName = regexp.MustCompile(`(?m)([\w -:_]*)\/\[runner.[\w:]*](\/[\w -:_]*)?`)
-	}
-	match := runnerRegexName.FindStringSubmatch(name)
-	if match == nil || len(match) == 0 {
-		return name
-	}
-	return match[1] + match[2]
-}
-
-func removeTestFailureFlag(t *testing.T) {
-	if t == nil {
-		return
-	}
+// Sets the test failure flag
+func setTestFailureFlag(t *testing.T, value bool) {
 	if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
-		if *(*bool)(ptr) == true {
-			*(*bool)(ptr) = false
-			if parentPtr, err := getFieldPointerOfT(t, "parent"); err == nil {
-				parentTPointer := (**testing.T)(parentPtr)
-				if parentTPointer != nil && *parentTPointer != nil {
-					removeTestFailureFlag(*parentTPointer)
-				}
-			}
+		*(*bool)(ptr) = value
+	}
+}
+
+// Gets the parent from a test
+func getTestParent(t *testing.T) *testing.T {
+	if parentPtr, err := getFieldPointerOfT(t, "parent"); err == nil {
+		parentTPointer := (**testing.T)(parentPtr)
+		if parentTPointer != nil && *parentTPointer != nil {
+			return *parentTPointer
 		}
 	}
+	return nil
 }
 
+// Gets a pointer of a private or public field in a testing.M struct
 func getFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) {
 	val := reflect.Indirect(reflect.ValueOf(m))
 	member := val.FieldByName(fieldName)
@@ -182,6 +191,7 @@ func getFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) 
 	return nil, errors.New("field can't be retrieved")
 }
 
+// Gets a pointer of a private or public field in a testing.T struct
 func getFieldPointerOfT(t *testing.T, fieldName string) (unsafe.Pointer, error) {
 	val := reflect.Indirect(reflect.ValueOf(t))
 	member := val.FieldByName(fieldName)
@@ -190,36 +200,4 @@ func getFieldPointerOfT(t *testing.T, fieldName string) (unsafe.Pointer, error) 
 		return ptrToY, nil
 	}
 	return nil, errors.New("field can't be retrieved")
-}
-
-func getTestResultsInfo(t *testing.T) *internalTestResult {
-	iTestResults := &internalTestResult{}
-	if ptr, err := getFieldPointerOfT(t, "ran"); err == nil {
-		iTestResults.ran = *(*bool)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
-		iTestResults.failed = *(*bool)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "skipped"); err == nil {
-		iTestResults.skipped = *(*bool)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "done"); err == nil {
-		iTestResults.done = *(*bool)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "finished"); err == nil {
-		iTestResults.finished = *(*bool)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "raceErrors"); err == nil {
-		iTestResults.raceErrors = *(*int)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "name"); err == nil {
-		iTestResults.name = *(*string)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "start"); err == nil {
-		iTestResults.start = *(*time.Time)(ptr)
-	}
-	if ptr, err := getFieldPointerOfT(t, "duration"); err == nil {
-		iTestResults.duration = *(*time.Duration)(ptr)
-	}
-	return iTestResults
 }

--- a/runner/main.go
+++ b/runner/main.go
@@ -156,23 +156,6 @@ func (r *testRunner) testProcessor(t *testing.T) {
 	}
 }
 
-func removeTestFailureFlag(t *testing.T) {
-	if t == nil {
-		return
-	}
-	if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
-		if *(*bool)(ptr) == true {
-			*(*bool)(ptr) = false
-			if parentPtr, err := getFieldPointerOfT(t, "parent"); err == nil {
-				parentTPointer := (**testing.T)(parentPtr)
-				if parentTPointer != nil && *parentTPointer != nil {
-					removeTestFailureFlag(*parentTPointer)
-				}
-			}
-		}
-	}
-}
-
 // Initialize test runner
 func (r *testRunner) init() {
 	tests := make([]testing.InternalTest, 0)
@@ -211,6 +194,23 @@ func (r *testRunner) init() {
 		}
 		// Replace internal benchmark
 		*r.intBenchmarks = benchmarks
+	}
+}
+
+func removeTestFailureFlag(t *testing.T) {
+	if t == nil {
+		return
+	}
+	if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
+		if *(*bool)(ptr) == true {
+			*(*bool)(ptr) = false
+			if parentPtr, err := getFieldPointerOfT(t, "parent"); err == nil {
+				parentTPointer := (**testing.T)(parentPtr)
+				if parentTPointer != nil && *parentTPointer != nil {
+					removeTestFailureFlag(*parentTPointer)
+				}
+			}
+		}
 	}
 }
 

--- a/runner/main.go
+++ b/runner/main.go
@@ -69,13 +69,13 @@ func Run(m *testing.M, exitOnError bool, failRetriesCount int) int {
 // Gets the test name
 func GetTestName(name string) string {
 	if runnerRegexName == nil {
-		runnerRegexName = regexp.MustCompile(`(?m)([\w -:_]*)\/\[runner.[\w:]*]`)
+		runnerRegexName = regexp.MustCompile(`(?m)([\w -:_]*)\/\[runner.[\w:]*](\/[\w -:_]*)?`)
 	}
 	match := runnerRegexName.FindStringSubmatch(name)
 	if match == nil || len(match) == 0 {
 		return name
 	}
-	return match[1]
+	return match[1] + match[2]
 }
 
 // Runs the test suite

--- a/runner/main.go
+++ b/runner/main.go
@@ -1,0 +1,269 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type (
+	testRunner struct {
+		m             *testing.M
+		intTests      *[]testing.InternalTest
+		intBenchmarks *[]testing.InternalBenchmark
+
+		tests      *map[string]*testDescriptor
+		benchmarks *map[string]*benchmarkDescriptor
+
+		failRetriesCount int
+		exitOnError      bool
+		exitCode         int
+	}
+	testDescriptor struct {
+		test    testing.InternalTest
+		fqn     string
+		ran     int
+		failed  bool
+		flaky   bool
+		error   bool
+		skipped bool
+	}
+	benchmarkDescriptor struct {
+		benchmark testing.InternalBenchmark
+		fqn       string
+		skipped   bool
+	}
+	internalTestResult struct {
+		ran        bool      // Test or benchmark (or one of its subtests) was executed.
+		failed     bool      // Test or benchmark has failed.
+		skipped    bool      // Test of benchmark has been skipped.
+		done       bool      // Test is finished and all subtests have completed.
+		finished   bool      // Test function has completed.
+		raceErrors int       // number of races detected during test
+		name       string    // Name of test or benchmark.
+		start      time.Time // Time test or benchmark started
+		duration   time.Duration
+	}
+)
+
+var runner *testRunner
+var runnerRegexName *regexp.Regexp
+
+// Runs a test suite
+func Run(m *testing.M, exitOnError bool, failRetriesCount int) int {
+	runner := &testRunner{
+		m:                m,
+		exitOnError:      exitOnError,
+		failRetriesCount: failRetriesCount,
+	}
+	runner.init()
+	return runner.Run()
+}
+
+// Gets the test name
+func GetTestName(name string) string {
+	if runnerRegexName == nil {
+		runnerRegexName = regexp.MustCompile(`(?m)([\w -:_]*)\/\[runner.[\w:]*]`)
+	}
+	match := runnerRegexName.FindStringSubmatch(name)
+	if match == nil || len(match) == 0 {
+		return name
+	}
+	return match[1]
+}
+
+// Runs the test suite
+func (r *testRunner) Run() int {
+	r.exitCode = 0
+	r.m.Run()
+	return r.exitCode
+}
+
+// Internal test processor, each test calls the processor in order to handle retries, process exiting and exitcodes
+func (r *testRunner) testProcessor(t *testing.T) {
+	t.Helper()
+	name := t.Name()
+	if item, ok := (*r.tests)[name]; ok {
+
+		//Sets the original test name
+		if pointer, err := getFieldPointerOfT(t, "name"); err == nil {
+			*(*string)(pointer) = item.test.Name
+		}
+
+		run := 1
+		maxRetries := r.failRetriesCount
+		exitOnError := r.exitOnError
+		var rc interface{}
+
+		for {
+			var innerTest *testing.T
+			title := "Run"
+			if run > 1 {
+				title = "Retry:" + strconv.Itoa(run-1)
+			}
+			title = "[runner." + title + "]"
+			t.Run(title, func(it *testing.T) {
+				defer func() {
+					rc = recover()
+					if rc != nil {
+						it.FailNow()
+					}
+				}()
+				it.Helper()
+				innerTest = it
+				item.test.F(it)
+			})
+			innerTestInfo := r.getTestResultsInfo(innerTest)
+
+			if rc != nil {
+				if exitOnError {
+					panic(rc)
+				}
+				fmt.Println("PANIC RECOVER:", rc)
+				item.error = true
+			}
+			item.skipped = innerTestInfo.skipped
+			item.ran++
+
+			// Current run failure
+			if innerTestInfo.failed {
+				item.failed = true
+			}
+			// Current run ok but previous with fail -> Flaky
+			if !innerTestInfo.failed && item.failed {
+				item.failed = false
+				item.flaky = true
+				break
+			}
+
+			if item.skipped || !item.failed || run > maxRetries {
+				break
+			}
+			run++
+		}
+		if item.flaky {
+			fmt.Println("*** FLAKY", item.fqn)
+		}
+		if item.error && exitOnError {
+			panic(rc)
+		}
+		if item.error || item.failed {
+			r.exitCode = 1
+		} else {
+			if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
+				*(*bool)(ptr) = false
+			}
+		}
+	} else {
+		t.FailNow()
+	}
+}
+
+// Initialize test runner
+func (r *testRunner) init() {
+	tests := make([]testing.InternalTest, 0)
+	benchmarks := make([]testing.InternalBenchmark, 0)
+
+	if tPointer, err := r.getFieldPointerOfM("tests"); err == nil {
+		r.intTests = (*[]testing.InternalTest)(tPointer)
+		r.tests = &map[string]*testDescriptor{}
+		for _, test := range *r.intTests {
+			fqn := test.Name
+			(*r.tests)[fqn] = &testDescriptor{
+				test:   test,
+				fqn:    fqn,
+				ran:    0,
+				failed: false,
+			}
+			tests = append(tests, testing.InternalTest{
+				Name: fqn,
+				F:    r.testProcessor,
+			})
+		}
+		// Replace internal tests
+		*r.intTests = tests
+	}
+	if bPointer, err := r.getFieldPointerOfM("benchmarks"); err == nil {
+		r.intBenchmarks = (*[]testing.InternalBenchmark)(bPointer)
+		r.benchmarks = &map[string]*benchmarkDescriptor{}
+
+		for _, benchmark := range *r.intBenchmarks {
+			fqn := benchmark.Name
+			(*r.benchmarks)[fqn] = &benchmarkDescriptor{
+				benchmark: benchmark,
+				fqn:       fqn,
+			}
+			benchmarks = append(benchmarks, benchmark)
+		}
+		// Replace internal benchmark
+		*r.intBenchmarks = benchmarks
+	}
+}
+
+func (r *testRunner) getFieldPointerOfM(fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(r.m))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, errors.New("field can't be retrieved")
+}
+
+func (r *testRunner) getFqnOfTest(tFunc func(*testing.T)) string {
+	funcVal := runtime.FuncForPC(reflect.ValueOf(tFunc).Pointer())
+	return funcVal.Name()
+}
+
+func (r *testRunner) getFqnOfBenchmark(bFunc func(*testing.B)) string {
+	funcVal := runtime.FuncForPC(reflect.ValueOf(bFunc).Pointer())
+	return funcVal.Name()
+}
+
+func getFieldPointerOfT(t *testing.T, fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(t))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, errors.New("field can't be retrieved")
+}
+
+func (r *testRunner) getTestResultsInfo(t *testing.T) *internalTestResult {
+	iTestResults := &internalTestResult{}
+	if ptr, err := getFieldPointerOfT(t, "ran"); err == nil {
+		iTestResults.ran = *(*bool)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "failed"); err == nil {
+		iTestResults.failed = *(*bool)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "skipped"); err == nil {
+		iTestResults.skipped = *(*bool)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "done"); err == nil {
+		iTestResults.done = *(*bool)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "finished"); err == nil {
+		iTestResults.finished = *(*bool)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "raceErrors"); err == nil {
+		iTestResults.raceErrors = *(*int)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "name"); err == nil {
+		iTestResults.name = *(*string)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "start"); err == nil {
+		iTestResults.start = *(*time.Time)(ptr)
+	}
+	if ptr, err := getFieldPointerOfT(t, "duration"); err == nil {
+		iTestResults.duration = *(*time.Duration)(ptr)
+	}
+	return iTestResults
+}


### PR DESCRIPTION
This `PR` adds retry support of failing tests.

The way to activate it is by using the `agent.WithRetriesOnFail` option in the `Run` method, is the only modification needed. If the option is not set then the standard test run executes.

By default in golang when a test produces a panic, the whole test suite crash. Because we are trying to apply retries in failing test the options has two arguments:

```go
func WithRetriesOnFail(retriesCount int, exitOnError bool) Option {
	return func(agent *Agent) {
		agent.failRetriesCount = retriesCount
		agent.exitOnError = exitOnError
	}
}
```

- The retries count.
- An option to recover from panic on a test in order to retry it

![image](https://user-images.githubusercontent.com/69803/70165526-59d84180-16c3-11ea-8b05-38dc0bf5bafc.png)

