### PR TITLE
Release span lock before ingest call

### DIFF
--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -113,7 +113,7 @@ func (r *SpanRecorder) SendSpans() error {
 	r.Lock()
 	spans := r.spans
 	r.spans = nil
-	defer r.Unlock()
+	r.Unlock()
 
 	r.totalSend = r.totalSend + 1
 
@@ -153,10 +153,6 @@ func (r *SpanRecorder) SendSpans() error {
 	if payloadSent {
 		r.okSend++
 	} else {
-		r.Lock()
-		r.spans = append(spans, r.spans...)
-		r.Unlock()
-		
 		r.koSend++
 		return lastError
 	}


### PR DESCRIPTION
fix #100 

This `PR` fixes the time penalty due the locking over the span slice in the recorder.

**Before:**
![image](https://user-images.githubusercontent.com/69803/71268468-585a7a80-234d-11ea-93ae-f74b55a26b82.png)

**After:**
![image](https://user-images.githubusercontent.com/69803/71268432-3b25ac00-234d-11ea-953a-a1f5043b544b.png)
