### PR TITLE
Remove multiple panics report

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -241,10 +241,8 @@ func NewAgent(options ...Option) (*Agent, error) {
 			return true
 		},
 		MaxLogsPerSpan: 10000,
-		OnSpanFinishPanic: func(rSpan *tracer.RawSpan, r interface{}) {
-			// Log the error in the current span
-			scopeError.LogErrorInRawSpan(rSpan, r)
-		},
+		// Log the error in the current span
+		OnSpanFinishPanic: scopeError.LogErrorInRawSpan,
 	})
 
 	instrumentation.SetTracer(agent.tracer)

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -199,7 +199,9 @@ func (test *Test) end() {
 	if r := recover(); r != nil {
 		test.span.SetTag("test.status", tags.TestStatus_FAIL)
 		test.span.SetTag("error", true)
-		errors.LogError(test.span, r, 1)
+		if r != errors.MarkSpanAsError {
+			errors.LogError(test.span, r, 1)
+		}
 		test.span.FinishWithOptions(finishOptions)
 		if test.onPanicHandler != nil {
 			test.onPanicHandler(test)

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -166,7 +166,7 @@ func (s *spanImpl) Finish() {
 	if s.tracer != nil && s.tracer.options.OnSpanFinishPanic != nil && s.raw.ParentSpanID != 0 {
 		if r := recover(); r != nil {
 			currentError = errors.Wrap(r, 1)
-			s.tracer.options.OnSpanFinishPanic(&s.raw, currentError)
+			s.tracer.options.OnSpanFinishPanic(&s.raw, &currentError)
 		}
 	}
 
@@ -199,7 +199,7 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	if s.tracer != nil && s.tracer.options.OnSpanFinishPanic != nil && s.raw.ParentSpanID != 0 {
 		if r := recover(); r != nil {
 			currentError = errors.Wrap(r, 1)
-			s.tracer.options.OnSpanFinishPanic(&s.raw, currentError)
+			s.tracer.options.OnSpanFinishPanic(&s.raw, &currentError)
 		}
 	}
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -3,6 +3,7 @@ package tracer
 import (
 	"time"
 
+	"github.com/go-errors/errors"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -91,7 +92,7 @@ type Options struct {
 	// conditions the code may panic.
 	EnableSpanPool bool
 	// Func to call when a panic has been detected when a span is finalizing
-	OnSpanFinishPanic func(rSpan *RawSpan, r interface{})
+	OnSpanFinishPanic func(rSpan *RawSpan, err **errors.Error)
 }
 
 // DefaultOptions returns an Options object with a 1 in 64 sampling rate and


### PR DESCRIPTION
Closes #113 

This `PR` removes the double panic report by writing the panic info the first time and then panicking a custom error to only mark the parent spans.

![image](https://user-images.githubusercontent.com/69803/72654276-2dd10100-398f-11ea-8ad0-09ccdeca5114.png)

![image](https://user-images.githubusercontent.com/69803/72654289-39242c80-398f-11ea-8e9c-12a852b0c422.png)

![image](https://user-images.githubusercontent.com/69803/72654316-5d800900-398f-11ea-8dc2-6de69d2e38f0.png)
