### PR TITLE
Benchmark auto instrumentation

### DIFF
--- a/init.go
+++ b/init.go
@@ -53,6 +53,11 @@ func GetContextFromTest(t *testing.T) context.Context {
 	return nil
 }
 
+// Gets the *Benchmark from a *testing.B
+func GetBenchmark(b *testing.B) *scopetesting.Benchmark {
+	return scopetesting.GetBenchmark(b)
+}
+
 // Instruments the given benchmark func
 //
 // Example of usage:

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -112,11 +112,6 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 			}
 		}
 		fullTestName = strings.Join(nameSegments, "/")
-
-		parentName := parentBenchmark.Name()
-		if strings.Index(fullTestName, parentName) == 0 && len(parentName) > 2 {
-			fullTestName = parentName[:len(parentName)-2] + fullTestName[len(parentName):]
-		}
 	}
 
 	testNameSlash := strings.IndexByte(fullTestName, '/')

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -1,0 +1,179 @@
+package testing
+
+import (
+	"context"
+	stdErrors "errors"
+	"fmt"
+	"math"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/opentracing/opentracing-go"
+
+	"go.undefinedlabs.com/scopeagent/ast"
+	"go.undefinedlabs.com/scopeagent/instrumentation"
+)
+
+type (
+	Benchmark struct {
+		b *testing.B
+	}
+)
+
+var (
+	instrumentedBenchmarkMutex sync.RWMutex
+	instrumentedBenchmark      = map[*testing.B]*Benchmark{}
+)
+
+// Starts a new benchmark using a pc as caller
+func StartBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
+	if !isBenchmarkInstrumented(b) {
+		// If the current benchmark is not instrumented, we instrument it.
+		startBenchmark(b, pc, benchFunc)
+	} else {
+		// If the benchmark is already instrumented, we passthrough to the benchFunc
+		benchFunc(b)
+	}
+}
+
+// Runs an auto instrumented sub benchmark
+func (bench *Benchmark) Run(name string, f func(b *testing.B)) bool {
+	pc, _, _, _ := runtime.Caller(1)
+	return bench.b.Run(name, func(innerB *testing.B) {
+		startBenchmark(innerB, pc, f)
+	})
+}
+
+// Adds an instrumented benchmark to the map
+func addInstrumentedBenchmark(b *testing.B, value *Benchmark) {
+	instrumentedBenchmarkMutex.Lock()
+	defer instrumentedBenchmarkMutex.Unlock()
+	instrumentedBenchmark[b] = value
+}
+
+// Gets if the benchmark is instrumented
+func isBenchmarkInstrumented(b *testing.B) bool {
+	instrumentedBenchmarkMutex.RLock()
+	defer instrumentedBenchmarkMutex.RUnlock()
+	_, ok := instrumentedBenchmark[b]
+	return ok
+}
+
+// Gets the Benchmark struct from *testing.Benchmark
+func GetBenchmark(b *testing.B) *Benchmark {
+	instrumentedBenchmarkMutex.RLock()
+	defer instrumentedBenchmarkMutex.RUnlock()
+	if bench, ok := instrumentedBenchmark[b]; ok {
+		return bench
+	}
+	return nil
+}
+
+func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
+	var bChild *testing.B
+	b.ReportAllocs()
+	b.ResetTimer()
+	startTime := time.Now()
+	result := b.Run("*", func(b1 *testing.B) {
+		addInstrumentedBenchmark(b1, &Benchmark{b: b1})
+		benchFunc(b1)
+		bChild = b1
+	})
+	if bChild == nil {
+		return
+	}
+	results, err := extractBenchmarkResult(bChild)
+	if err != nil {
+		instrumentation.Logger().Printf("Error while extracting the benchmark result object: %v\n", err)
+		return
+	}
+
+	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
+	// to search the func source code bounds and to calculate the package name.
+	fullTestName := b.Name()
+
+	// We detect if the parent benchmark is instrumented, and if so we remove the "*" SubBenchmark from the previous instrumentation
+	parentBenchmark := getParentBenchmark(b)
+	if parentBenchmark != nil && isBenchmarkInstrumented(parentBenchmark) {
+		parentName := parentBenchmark.Name()
+		if strings.Index(fullTestName, parentName) == 0 && len(parentName) > 2 {
+			fullTestName = parentName[:len(parentName)-2] + fullTestName[len(parentName):]
+		}
+	}
+
+	testNameSlash := strings.IndexByte(fullTestName, '/')
+	funcName := fullTestName
+	if testNameSlash >= 0 {
+		funcName = fullTestName[:testNameSlash]
+	}
+	packageName := getBenchmarkSuiteName(b)
+
+	sourceBounds, _ := ast.GetFuncSourceForName(pc, funcName)
+	var testCode string
+	if sourceBounds != nil {
+		testCode = fmt.Sprintf("%s:%d:%d", sourceBounds.File, sourceBounds.Start.Line, sourceBounds.End.Line)
+	}
+
+	var startOptions []opentracing.StartSpanOption
+	startOptions = append(startOptions, opentracing.Tags{
+		"span.kind":      "test",
+		"test.name":      fullTestName,
+		"test.suite":     packageName,
+		"test.code":      testCode,
+		"test.framework": "testing",
+		"test.language":  "go",
+		"test.type":      "benchmark",
+	}, opentracing.StartTime(startTime))
+
+	span, _ := opentracing.StartSpanFromContextWithTracer(context.Background(), instrumentation.Tracer(), fullTestName, startOptions...)
+	span.SetBaggageItem("trace.kind", "test")
+	avg := math.Round((float64(results.T.Nanoseconds())/float64(results.N))*100) / 100
+	span.SetTag("benchmark.runs", results.N)
+	span.SetTag("benchmark.duration.mean", avg)
+	span.SetTag("benchmark.memory.mean_allocations", results.AllocsPerOp())
+	span.SetTag("benchmark.memory.mean_bytes_allocations", results.AllocedBytesPerOp())
+	if result {
+		span.SetTag("test.status", "PASS")
+	} else {
+		span.SetTag("test.status", "FAIL")
+	}
+	span.FinishWithOptions(opentracing.FinishOptions{
+		FinishTime: startTime.Add(results.T),
+	})
+}
+
+func getParentBenchmark(b *testing.B) *testing.B {
+	val := reflect.Indirect(reflect.ValueOf(b))
+	member := val.FieldByName("parent")
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return *(**testing.B)(ptrToY)
+	}
+	return nil
+}
+
+func getBenchmarkSuiteName(b *testing.B) string {
+	val := reflect.Indirect(reflect.ValueOf(b))
+	member := val.FieldByName("importPath")
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return *(*string)(ptrToY)
+	}
+	return ""
+}
+
+//Extract benchmark result from the private result field in testing.B
+func extractBenchmarkResult(b *testing.B) (*testing.BenchmarkResult, error) {
+	val := reflect.Indirect(reflect.ValueOf(b))
+	member := val.FieldByName("result")
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return (*testing.BenchmarkResult)(ptrToY), nil
+	}
+	return nil, stdErrors.New("result can't be retrieved")
+}

--- a/instrumentation/testing/init.go
+++ b/instrumentation/testing/init.go
@@ -1,0 +1,57 @@
+package testing
+
+import (
+	stdErrors "errors"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// Initialize the testing instrumentation
+func Init(m *testing.M) {
+	if tPointer, err := getFieldPointerOfM(m, "tests"); err == nil {
+		intTests := (*[]testing.InternalTest)(tPointer)
+		tests := make([]testing.InternalTest, 0)
+		for _, test := range *intTests {
+			funcValue := test.F
+			funcPointer := reflect.ValueOf(funcValue).Pointer()
+			tests = append(tests, testing.InternalTest{
+				Name: test.Name,
+				F: func(t *testing.T) { // Creating a new test function as an indirection of the original test
+					addAutoInstrumentedTest(t)
+					tStruct := StartTestFromCaller(t, funcPointer)
+					defer tStruct.end()
+					funcValue(t)
+				},
+			})
+		}
+		// Replace internal tests with new test indirection
+		*intTests = tests
+	}
+	if bPointer, err := getFieldPointerOfM(m, "benchmarks"); err == nil {
+		intBenchmarks := (*[]testing.InternalBenchmark)(bPointer)
+		var benchmarks []testing.InternalBenchmark
+		for _, benchmark := range *intBenchmarks {
+			funcValue := benchmark.F
+			funcPointer := reflect.ValueOf(funcValue).Pointer()
+			benchmarks = append(benchmarks, testing.InternalBenchmark{
+				Name: benchmark.Name,
+				F: func(b *testing.B) { // Indirection of the original benchmark
+					startBenchmark(b, funcPointer, funcValue)
+				},
+			})
+		}
+		*intBenchmarks = benchmarks
+	}
+}
+
+// Gets a private field from the testing.M struct using reflection
+func getFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) {
+	val := reflect.Indirect(reflect.ValueOf(m))
+	member := val.FieldByName(fieldName)
+	if member.IsValid() {
+		ptrToY := unsafe.Pointer(member.UnsafeAddr())
+		return ptrToY, nil
+	}
+	return nil, stdErrors.New("field can't be retrieved")
+}

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -2,9 +2,7 @@ package testing
 
 import (
 	"context"
-	stdErrors "errors"
 	"fmt"
-	"math"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -38,10 +36,6 @@ type (
 	}
 
 	Option func(*Test)
-
-	Benchmark struct {
-		b *testing.B
-	}
 )
 
 var (
@@ -50,51 +44,10 @@ var (
 	autoInstrumentedTestsMutex sync.RWMutex
 	autoInstrumentedTests      = map[*testing.T]bool{}
 
-	instrumentedBenchmarkMutex sync.RWMutex
-	instrumentedBenchmark      = map[*testing.B]*Benchmark{}
-
 	defaultPanicHandler = func(test *Test) {}
 
 	TESTING_LOG_REGEX = regexp.MustCompile(`(?m)^ {4}(?P<file>[\w\/\.]+):(?P<line>\d+): (?P<message>(.*\n {8}.*)*.*)`)
 )
-
-// Initialize the testing instrumentation
-func Init(m *testing.M) {
-	if tPointer, err := getFieldPointerOfM(m, "tests"); err == nil {
-		intTests := (*[]testing.InternalTest)(tPointer)
-		tests := make([]testing.InternalTest, 0)
-		for _, test := range *intTests {
-			funcValue := test.F
-			funcPointer := reflect.ValueOf(funcValue).Pointer()
-			tests = append(tests, testing.InternalTest{
-				Name: test.Name,
-				F: func(t *testing.T) { // Creating a new test function as an indirection of the original test
-					addAutoInstrumentedTest(t)
-					tStruct := StartTestFromCaller(t, funcPointer)
-					defer tStruct.end()
-					funcValue(t)
-				},
-			})
-		}
-		// Replace internal tests with new test indirection
-		*intTests = tests
-	}
-	if bPointer, err := getFieldPointerOfM(m, "benchmarks"); err == nil {
-		intBenchmarks := (*[]testing.InternalBenchmark)(bPointer)
-		var benchmarks []testing.InternalBenchmark
-		for _, benchmark := range *intBenchmarks {
-			funcValue := benchmark.F
-			funcPointer := reflect.ValueOf(funcValue).Pointer()
-			benchmarks = append(benchmarks, testing.InternalBenchmark{
-				Name: benchmark.Name,
-				F: func(b *testing.B) { // Indirection of the original benchmark
-					startBenchmark(b, funcPointer, funcValue)
-				},
-			})
-		}
-		*intBenchmarks = benchmarks
-	}
-}
 
 // Options for starting a new test
 func WithContext(ctx context.Context) Option {
@@ -340,168 +293,9 @@ func addAutoInstrumentedTest(t *testing.T) {
 	autoInstrumentedTests[t] = true
 }
 
-// Starts a new benchmark using a pc as caller
-func StartBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
-	if !isBenchmarkInstrumented(b) {
-		// If the current benchmark is not instrumented, we instrument it.
-		startBenchmark(b, pc, benchFunc)
-	} else {
-		// If the benchmark is already instrumented, we passthrough to the benchFunc
-		benchFunc(b)
-	}
-}
-
-// Runs an auto instrumented sub benchmark
-func (bench *Benchmark) Run(name string, f func(b *testing.B)) bool {
-	pc, _, _, _ := runtime.Caller(1)
-	return bench.b.Run(name, func(innerB *testing.B) {
-		startBenchmark(innerB, pc, f)
-	})
-}
-
-// Adds an instrumented benchmark to the map
-func addInstrumentedBenchmark(b *testing.B, value *Benchmark) {
-	instrumentedBenchmarkMutex.Lock()
-	defer instrumentedBenchmarkMutex.Unlock()
-	instrumentedBenchmark[b] = value
-}
-
-// Gets if the benchmark is instrumented
-func isBenchmarkInstrumented(b *testing.B) bool {
-	instrumentedBenchmarkMutex.RLock()
-	defer instrumentedBenchmarkMutex.RUnlock()
-	_, ok := instrumentedBenchmark[b]
-	return ok
-}
-
-// Gets the Benchmark struct from *testing.Benchmark
-func GetBenchmark(b *testing.B) *Benchmark {
-	instrumentedBenchmarkMutex.RLock()
-	defer instrumentedBenchmarkMutex.RUnlock()
-	if bench, ok := instrumentedBenchmark[b]; ok {
-		return bench
-	}
-	return nil
-}
-
-func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
-	var bChild *testing.B
-	b.ReportAllocs()
-	b.ResetTimer()
-	startTime := time.Now()
-	result := b.Run("*", func(b1 *testing.B) {
-		addInstrumentedBenchmark(b1, &Benchmark{b: b1})
-		benchFunc(b1)
-		bChild = b1
-	})
-	if bChild == nil {
-		return
-	}
-	results, err := extractBenchmarkResult(bChild)
-	if err != nil {
-		instrumentation.Logger().Printf("Error while extracting the benchmark result object: %v\n", err)
-		return
-	}
-
-	// Extracting the benchmark func name (by removing any possible sub-benchmark suffix `{bench_func}/{sub_benchmark}`)
-	// to search the func source code bounds and to calculate the package name.
-	fullTestName := b.Name()
-
-	// We detect if the parent benchmark is instrumented, and if so we remove the "*" SubBenchmark from the previous instrumentation
-	parentBenchmark := getParentBenchmark(b)
-	if parentBenchmark != nil && isBenchmarkInstrumented(parentBenchmark) {
-		parentName := parentBenchmark.Name()
-		if strings.Index(fullTestName, parentName) == 0 && len(parentName) > 2 {
-			fullTestName = parentName[:len(parentName)-2] + fullTestName[len(parentName):]
-		}
-	}
-
-	testNameSlash := strings.IndexByte(fullTestName, '/')
-	funcName := fullTestName
-	if testNameSlash >= 0 {
-		funcName = fullTestName[:testNameSlash]
-	}
-	packageName := getBenchmarkSuiteName(b)
-
-	sourceBounds, _ := ast.GetFuncSourceForName(pc, funcName)
-	var testCode string
-	if sourceBounds != nil {
-		testCode = fmt.Sprintf("%s:%d:%d", sourceBounds.File, sourceBounds.Start.Line, sourceBounds.End.Line)
-	}
-
-	var startOptions []opentracing.StartSpanOption
-	startOptions = append(startOptions, opentracing.Tags{
-		"span.kind":      "test",
-		"test.name":      fullTestName,
-		"test.suite":     packageName,
-		"test.code":      testCode,
-		"test.framework": "testing",
-		"test.language":  "go",
-		"test.type":      "benchmark",
-	}, opentracing.StartTime(startTime))
-
-	span, _ := opentracing.StartSpanFromContextWithTracer(context.Background(), instrumentation.Tracer(), fullTestName, startOptions...)
-	span.SetBaggageItem("trace.kind", "test")
-	avg := math.Round((float64(results.T.Nanoseconds())/float64(results.N))*100) / 100
-	span.SetTag("benchmark.runs", results.N)
-	span.SetTag("benchmark.duration.mean", avg)
-	span.SetTag("benchmark.memory.mean_allocations", results.AllocsPerOp())
-	span.SetTag("benchmark.memory.mean_bytes_allocations", results.AllocedBytesPerOp())
-	if result {
-		span.SetTag("test.status", "PASS")
-	} else {
-		span.SetTag("test.status", "FAIL")
-	}
-	span.FinishWithOptions(opentracing.FinishOptions{
-		FinishTime: startTime.Add(results.T),
-	})
-}
-
-func getParentBenchmark(b *testing.B) *testing.B {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("parent")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return *(**testing.B)(ptrToY)
-	}
-	return nil
-}
-
-func getBenchmarkSuiteName(b *testing.B) string {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("importPath")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return *(*string)(ptrToY)
-	}
-	return ""
-}
-
-//Extract benchmark result from the private result field in testing.B
-func extractBenchmarkResult(b *testing.B) (*testing.BenchmarkResult, error) {
-	val := reflect.Indirect(reflect.ValueOf(b))
-	member := val.FieldByName("result")
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return (*testing.BenchmarkResult)(ptrToY), nil
-	}
-	return nil, stdErrors.New("result can't be retrieved")
-}
-
 // Sets the default panic handler
 func SetDefaultPanicHandler(handler func(*Test)) {
 	if handler != nil {
 		defaultPanicHandler = handler
 	}
-}
-
-// Gets a private field from the testing.M struct using reflection
-func getFieldPointerOfM(m *testing.M, fieldName string) (unsafe.Pointer, error) {
-	val := reflect.Indirect(reflect.ValueOf(m))
-	member := val.FieldByName(fieldName)
-	if member.IsValid() {
-		ptrToY := unsafe.Pointer(member.UnsafeAddr())
-		return ptrToY, nil
-	}
-	return nil, stdErrors.New("field can't be retrieved")
 }

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -82,7 +82,7 @@ func Init(m *testing.M) {
 			funcPointer := reflect.ValueOf(funcValue).Pointer()
 			benchmarks = append(benchmarks, testing.InternalBenchmark{
 				Name: benchmark.Name,
-				F: func(b *testing.B) { // Indirection of a original benchmark
+				F: func(b *testing.B) { // Indirection of the original benchmark
 					startBenchmark(b, funcPointer, funcValue)
 				},
 			})
@@ -345,8 +345,10 @@ func addInstrumentedBenchmark(b *testing.B) {
 // Starts a new benchmark using a pc as caller
 func StartBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 	if !isBenchmarkInstrumented(b) {
+		// If the current benchmark is not instrumented, we instrument it.
 		startBenchmark(b, pc, benchFunc)
 	} else {
+		// If the benchmark is already instrumented, we passthrough to the benchFunc
 		benchFunc(b)
 	}
 }
@@ -395,7 +397,7 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 	if testNameSlash >= 0 {
 		funcName = fullTestName[:testNameSlash]
 	}
-	packageName := getBenchmarkSuite(b)
+	packageName := getBenchmarkSuiteName(b)
 
 	sourceBounds, _ := ast.GetFuncSourceForName(pc, funcName)
 	var testCode string
@@ -441,7 +443,7 @@ func getParentBenchmark(b *testing.B) *testing.B {
 	return nil
 }
 
-func getBenchmarkSuite(b *testing.B) string {
+func getBenchmarkSuiteName(b *testing.B) string {
 	val := reflect.Indirect(reflect.ValueOf(b))
 	member := val.FieldByName("importPath")
 	if member.IsValid() {


### PR DESCRIPTION
This `PR` enables Benchmark auto instrumentation.

Supports all variants, this 4 benchmarks:

<img width="373" alt="image" src="https://user-images.githubusercontent.com/69803/72846678-5b74bd80-3ca1-11ea-880d-6904f6ce94ee.png">

Are reported as:

<img width="891" alt="image" src="https://user-images.githubusercontent.com/69803/72846724-6e878d80-3ca1-11ea-9a19-ef0d9cf758e0.png">

The same in standard output:

<img width="607" alt="image" src="https://user-images.githubusercontent.com/69803/72846781-8b23c580-3ca1-11ea-8c21-963530ad407d.png">
