### PR TITLE
Fix http 401 response handler

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -305,7 +305,8 @@ func (a *Agent) Flush() error {
 	if a.debugMode {
 		a.logger.Println("Scope agent is flushing all pending spans manually")
 	}
-	return a.recorder.SendSpans()
+	err, _ := a.recorder.SendSpans()
+	return err
 }
 
 func generateAgentID() string {

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -102,6 +102,7 @@ func (r *SpanRecorder) loop() error {
 				}
 				if shouldExit {
 					ticker.Stop()
+					r.t.Kill(err)
 					return nil
 				}
 			}
@@ -167,10 +168,9 @@ func (r *SpanRecorder) SendSpans() (error, bool) {
 		r.okSend++
 	} else {
 		r.koSend++
-		return lastError, shouldExit
 	}
 
-	return nil, shouldExit
+	return lastError, shouldExit
 }
 
 // Sends the encoded `payload` to the Scope ingest endpoint

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -64,6 +64,10 @@ func NewSpanRecorder(agent *Agent) *SpanRecorder {
 func (r *SpanRecorder) RecordSpan(span tracer.RawSpan) {
 	r.Lock()
 	defer r.Unlock()
+	if !r.t.Alive() {
+		r.logger.Printf("an span is received but the recorder is already disposed.\n")
+		return
+	}
 	r.spans = append(r.spans, span)
 	if r.debugMode {
 		r.logger.Printf("record span: %+v\n", span)


### PR DESCRIPTION
This `PR` changes the behavior on 401 responses from backend.

Now when a 401 response is received the recorder stop sending all data and marked as disposed. New `RecordSpan` calls will write the disposed error to the log file.
