### PR TITLE
Improvements in the grpc instrumentation

### DIFF
--- a/instrumentation/grpc/errors.go
+++ b/instrumentation/grpc/errors.go
@@ -21,6 +21,33 @@ const (
 	ServerError Class = "5xx"
 )
 
+var classStrings = map[Class]string{
+	Unknown:     "Unknown (0xx)",
+	Success:     "Success (2xx)",
+	ClientError: "ClientError (4xx)",
+	ServerError: "ServerError (5xx)",
+}
+
+var codeStrings = map[codes.Code]string{
+	codes.OK:                 "OK",
+	codes.Canceled:           "Canceled",
+	codes.Unknown:            "Unknown",
+	codes.InvalidArgument:    "InvalidArgument",
+	codes.DeadlineExceeded:   "DeadlineExceeded",
+	codes.NotFound:           "NotFound",
+	codes.AlreadyExists:      "AlreadyExists",
+	codes.PermissionDenied:   "PermissionDenied",
+	codes.ResourceExhausted:  "ResourceExhausted",
+	codes.FailedPrecondition: "FailedPrecondition",
+	codes.Aborted:            "Aborted",
+	codes.OutOfRange:         "OutOfRange",
+	codes.Unimplemented:      "Unimplemented",
+	codes.Internal:           "Internal",
+	codes.Unavailable:        "Unavailable",
+	codes.DataLoss:           "DataLoss",
+	codes.Unauthenticated:    "Unauthenticated",
+}
+
 // ErrorClass returns the class of the given error
 func ErrorClass(err error) Class {
 	if s, ok := status.FromError(err); ok {
@@ -58,8 +85,8 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	if s, ok := status.FromError(err); ok {
 		code = s.Code()
 	}
-	span.SetTag(Status, code)
-	span.SetTag("response_class", c)
+	span.SetTag(Status, codeStrings[code])
+	span.SetTag("response_class", classStrings[c])
 	if err == nil {
 		return
 	}

--- a/instrumentation/grpc/errors.go
+++ b/instrumentation/grpc/errors.go
@@ -85,8 +85,17 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	if s, ok := status.FromError(err); ok {
 		code = s.Code()
 	}
-	span.SetTag(Status, codeStrings[code])
-	span.SetTag("response_class", classStrings[c])
+	if value, ok := codeStrings[code]; ok {
+		span.SetTag(Status, value)
+	} else {
+		span.SetTag(Status, code)
+	}
+	if value, ok := classStrings[c]; ok {
+		span.SetTag("response_class", value)
+	} else {
+		span.SetTag("response_class", c)
+	}
+
 	if err == nil {
 		return
 	}

--- a/instrumentation/grpc/server.go
+++ b/instrumentation/grpc/server.go
@@ -11,7 +11,6 @@ import (
 )
 
 // OpenTracingServerInterceptor returns a grpc.UnaryServerInterceptor suitable
-// ScopeServerInterceptor returns a grpc.UnaryServerInterceptor suitable
 // for use in a grpc.NewServer call.
 //
 // For example:
@@ -78,7 +77,6 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 }
 
 // OpenTracingStreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
-// ScopeStreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
 // for use in a grpc.NewServer call. The interceptor instruments streaming RPCs by
 // creating a single span to correspond to the lifetime of the RPC's stream.
 //


### PR DESCRIPTION
- The tracer is loaded by demand in case is NoopTracer: This fixes the cases when a grpc server or client are declared in the `TestMain` before the `scopeagent.Run` call, so the NoopTracer is used in the interceptors.

- Better error reporting with Codes and Class transformed to strings: Currently the constant values are sent in the original format, so for codes is an int. Now changes the value to the name of the constant.
