### PR TITLE
Runner improvements

### DIFF
--- a/agent/util.go
+++ b/agent/util.go
@@ -18,6 +18,18 @@ func getBoolEnv(key string, fallback bool) bool {
 	return value
 }
 
+func getIntEnv(key string, fallback int) int {
+	stringValue, exists := os.LookupEnv(key)
+	if !exists {
+		return fallback
+	}
+	value, err := strconv.ParseInt(stringValue, 0, 0)
+	if err != nil {
+		panic(fmt.Sprintf("unable to parse %s - should be 'true' or 'false'", key))
+	}
+	return int(value)
+}
+
 func addToMapIfEmpty(dest map[string]interface{}, source map[string]interface{}) {
 	for k, newValue := range source {
 		if oldValue, ok := dest[k]; !ok || oldValue == "" {

--- a/agent/util.go
+++ b/agent/util.go
@@ -25,7 +25,7 @@ func getIntEnv(key string, fallback int) int {
 	}
 	value, err := strconv.ParseInt(stringValue, 0, 0)
 	if err != nil {
-		panic(fmt.Sprintf("unable to parse %s - should be 'true' or 'false'", key))
+		panic(fmt.Sprintf("unable to parse %s - does not seem to be an int", key))
 	}
 	return int(value)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,13 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -6,15 +6,16 @@ import (
 )
 
 var (
-	okCount    = 0
-	failCount  = 0
-	errorCount = 0
-	flakyCount = 0
+	okCount     = 0
+	failCount   = 0
+	errorCount  = 0
+	flakyCount  = 0
+	failSubTest = 0
 )
 
 func TestMain(m *testing.M) {
-	Run(m, false, 4, nil)
-	fmt.Println(okCount, failCount, errorCount, flakyCount)
+	Run(m, true, 4, nil)
+	fmt.Println(okCount, failCount, errorCount, flakyCount, failSubTest)
 	if okCount != 1 {
 		panic("TestOk ran an unexpected number of times")
 	}
@@ -27,26 +28,58 @@ func TestMain(m *testing.M) {
 	if flakyCount != 3 {
 		panic("TestFlaky ran an unexpected number of times")
 	}
+	if failCount != 5 {
+		panic("TestFailSubTest ran an unexpected number of times")
+	}
 }
 
 func TestOk(t *testing.T) {
+	if GetOriginalTestName(t.Name()) != "TestOk" {
+		t.Fatal("test name is invalid.")
+	}
 	okCount++
 	t.Log("Ok")
 }
 
 func TestFail(t *testing.T) {
+	if GetOriginalTestName(t.Name()) != "TestFail" {
+		t.Fatal("test name is invalid.")
+	}
 	failCount++
 	t.Fatal("Fail")
 }
 
 func TestError(t *testing.T) {
+	if GetOriginalTestName(t.Name()) != "TestError" {
+		t.Fatal("test name is invalid.")
+	}
 	errorCount++
 	panic("this is a panic")
 }
 
 func TestFlaky(t *testing.T) {
+	if GetOriginalTestName(t.Name()) != "TestFlaky" {
+		t.Fatal("test name is invalid.")
+	}
 	flakyCount++
 	if flakyCount != 3 {
 		t.Fatal("this is flaky")
 	}
+}
+
+func TestFailSubTest(t *testing.T) {
+	t.Run("SubTest", func(t *testing.T) {
+		if GetOriginalTestName(t.Name()) != "TestFailSubTest/SubTest" {
+			t.Fatal("test name is invalid.")
+		}
+
+		t.Run("SubSub", func(t *testing.T) {
+			if GetOriginalTestName(t.Name()) != "TestFailSubTest/SubTest/SubSub" {
+				t.Fatal("test name is invalid.")
+			}
+		})
+
+		failSubTest++
+		t.Fatal("Subtest fail")
+	})
 }


### PR DESCRIPTION
- Added support for Env Vars configuration using `SCOPE_TESTING_FAIL_RETRIES` and `SCOPE_TESTING_PANIC_AS_FAIL`
- Changed `exitOnError` to `panicAsFail`
- Runner changes to avoid the `[exec] / [group]` subtest to appear in the standard output (by setting the chatty and name field of a test)

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/69803/73799051-0b275080-47b5-11ea-835c-edd1c487e270.png">

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/69803/73799060-167a7c00-47b5-11ea-89df-8ff1a3b340d1.png">
