### PR TITLE
Fix support for import autoinstrument and TestMain scopeagent.Run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,10 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/init.go
+++ b/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -15,10 +16,19 @@ import (
 	scopetesting "go.undefinedlabs.com/scopeagent/instrumentation/testing"
 )
 
-var defaultAgent *agent.Agent
+var (
+	defaultAgent *agent.Agent
+	runningMutex sync.Mutex
+	running      bool
+)
 
 // Helper function to run a `testing.M` object and gracefully stopping the agent afterwards
 func Run(m *testing.M, opts ...agent.Option) int {
+	if getRunningFlag() {
+		return m.Run()
+	}
+	setRunningFlag(true)
+	defer setRunningFlag(false)
 	opts = append(opts, agent.WithTestingModeEnabled())
 	newAgent, err := agent.NewAgent(opts...)
 	if err != nil {
@@ -129,4 +139,15 @@ func GetBenchmark(b *testing.B) *scopetesting.Benchmark {
 func StartBenchmark(b *testing.B, benchFunc func(b *testing.B)) {
 	pc, _, _, _ := runtime.Caller(1)
 	scopetesting.StartBenchmark(b, pc, benchFunc)
+}
+
+func setRunningFlag(value bool) {
+	runningMutex.Lock()
+	defer runningMutex.Unlock()
+	running = value
+}
+func getRunningFlag() bool {
+	runningMutex.Lock()
+	defer runningMutex.Unlock()
+	return running
 }

--- a/init.go
+++ b/init.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	defaultAgent *agent.Agent
-	runningMutex sync.Mutex
+	runningMutex sync.RWMutex
 	running      bool
 )
 
@@ -147,7 +147,7 @@ func setRunningFlag(value bool) {
 	running = value
 }
 func getRunningFlag() bool {
-	runningMutex.Lock()
-	defer runningMutex.Unlock()
+	runningMutex.RLock()
+	defer runningMutex.RUnlock()
 	return running
 }


### PR DESCRIPTION
Fix support for `import autoinstrument` and `TestMain scopeagent.Run` call in the same package without creating agents and patching twice.

The import auto instrumentation patch the `m.Run` method to call `scopeagent.Run`, then if we call `scopeagent.Run` in the `TestMain` manually, will call this patched version of `m.Run` resulting in calling `scopeagent.Run` twice, and patching and creating two agents.

By setting a flag we can avoid the recursive call.