### PR TITLE
Fix go vet in the agent

### DIFF
--- a/instrumentation/testing/logger.go
+++ b/instrumentation/testing/logger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/undefinedlabs/go-mpatch"
 
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	"go.undefinedlabs.com/scopeagent/reflection"
 )
 
 var (
@@ -22,10 +23,8 @@ var (
 
 func init() {
 	// We get the *testing.common type to use in the patch method
-	var t testing.T
-	typeOfT := reflect.TypeOf(t)
-	if cm, ok := typeOfT.FieldByName("common"); ok {
-		commonPtr = reflect.PtrTo(cm.Type)
+	if cPtr, err := reflection.GetTypePointer(testing.T{}, "common"); err == nil {
+		commonPtr = cPtr
 	}
 }
 

--- a/reflection/reflect.go
+++ b/reflection/reflect.go
@@ -28,6 +28,15 @@ func GetFieldPointerOfLogger(logger *stdlog.Logger, fieldName string) (unsafe.Po
 	return getFieldPointerOf(logger, fieldName)
 }
 
+// Gets the type pointer to a field name
+func GetTypePointer(i interface{}, fieldName string) (reflect.Type, error) {
+	typeOf := reflect.Indirect(reflect.ValueOf(i)).Type()
+	if member, ok := typeOf.FieldByName(fieldName); ok {
+		return reflect.PtrTo(member.Type), nil
+	}
+	return nil, errors.New("field can't be retrieved")
+}
+
 func getFieldPointerOf(i interface{}, fieldName string) (unsafe.Pointer, error) {
 	val := reflect.Indirect(reflect.ValueOf(i))
 	member := val.FieldByName(fieldName)


### PR DESCRIPTION
This `PR` fixes the `go vet ./...` command in the agent.

**Before:**

![image](https://user-images.githubusercontent.com/69803/74346629-234c3080-4db0-11ea-95db-d0e2b0eda70c.png)


**After:**

![image](https://user-images.githubusercontent.com/69803/74346582-13cce780-4db0-11ea-9548-9f176087f494.png)

