### PR TITLE
Http server instrumentation, panic support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,10 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/instrumentation/nethttp/server.go
+++ b/instrumentation/nethttp/server.go
@@ -2,7 +2,6 @@ package nethttp
 
 import (
 	"bytes"
-	"go.undefinedlabs.com/scopeagent/env"
 	"net"
 	"net/http"
 	"net/url"
@@ -12,6 +11,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 
+	"go.undefinedlabs.com/scopeagent/env"
+	"go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 )
 
@@ -178,6 +179,15 @@ func middlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 			} else {
 				sp.SetTag("http.response_payload.unavailable", "disabled")
 			}
+
+			if r := recover(); r != nil {
+				if r != errors.MarkSpanAsError {
+					errors.LogError(sp, r, 1)
+				}
+				sp.Finish()
+				panic(r)
+			}
+
 			sp.Finish()
 		}()
 


### PR DESCRIPTION
This `PR` adds support for panic report on http server request.

Currently when an http request panic, the span is finished but the panic is not stored as an exception. This `PR` fixes that.