### PR TITLE
Support to split a big payload in multiples payloads

### DIFF
--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -145,7 +145,9 @@ func (r *SpanRecorder) sendSpans() (error, bool) {
 	var lastError error
 	for b := 0; b <= batchLength; b++ {
 		var batch []tracer.RawSpan
+		// We extract the batch of spans to be send
 		if b == batchLength {
+			// If we are in the last batch, we select the remaining spans
 			batch = spans[b*batchSize:]
 		} else {
 			batch = spans[b*batchSize : ((b + 1) * batchSize)]

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -135,38 +135,57 @@ func (r *SpanRecorder) loop() error {
 // Sends the spans in the buffer to Scope
 func (r *SpanRecorder) sendSpans() (error, bool) {
 	atomic.AddInt64(&r.stats.sendSpansCalls, 1)
-
 	spans := r.popSpans()
-	payload := r.getPayload(spans)
 
-	buf, err := encodePayload(payload)
-	if err != nil {
-		atomic.AddInt64(&r.stats.sendSpansKo, 1)
-		atomic.AddInt64(&r.stats.spansNotSent, int64(len(spans)))
-		return err, false
-	}
+	const batchSize = 1000
+	batchLength := len(spans) / batchSize
 
-	var testSpans int64
-	for _, span := range spans {
-		if isTestSpan(span) {
-			testSpans++
+	r.logger.Printf("sending %d spans in %d batches", len(spans), batchLength+1)
+
+	var lastError error
+	for b := 0; b <= batchLength; b++ {
+		var batch []tracer.RawSpan
+		if b == batchLength {
+			batch = spans[b*batchSize:]
+		} else {
+			batch = spans[b*batchSize : ((b + 1) * batchSize)]
 		}
-	}
 
-	statusCode, err := r.callIngest(buf)
-	if err != nil {
-		atomic.AddInt64(&r.stats.sendSpansKo, 1)
-		atomic.AddInt64(&r.stats.spansNotSent, int64(len(spans)))
-		atomic.AddInt64(&r.stats.testSpansNotSent, testSpans)
-	} else {
-		atomic.AddInt64(&r.stats.sendSpansOk, 1)
-		atomic.AddInt64(&r.stats.spansSent, int64(len(spans)))
-		atomic.AddInt64(&r.stats.testSpansSent, testSpans)
+		payload := r.getPayload(batch)
+
+		buf, err := encodePayload(payload)
+		if err != nil {
+			atomic.AddInt64(&r.stats.sendSpansKo, 1)
+			atomic.AddInt64(&r.stats.spansNotSent, int64(len(spans)))
+			return err, false
+		}
+
+		var testSpans int64
+		for _, span := range batch {
+			if isTestSpan(span) {
+				testSpans++
+			}
+		}
+
+		if batchLength > 0 {
+			r.logger.Printf("sending batch %d with %d spans", b+1, len(batch))
+		}
+		statusCode, err := r.callIngest(buf)
+		if err != nil {
+			atomic.AddInt64(&r.stats.sendSpansKo, 1)
+			atomic.AddInt64(&r.stats.spansNotSent, int64(len(spans)))
+			atomic.AddInt64(&r.stats.testSpansNotSent, testSpans)
+		} else {
+			atomic.AddInt64(&r.stats.sendSpansOk, 1)
+			atomic.AddInt64(&r.stats.spansSent, int64(len(spans)))
+			atomic.AddInt64(&r.stats.testSpansSent, testSpans)
+		}
+		if statusCode == 401 {
+			return err, true
+		}
+		lastError = err
 	}
-	if statusCode == 401 {
-		return err, true
-	}
-	return err, false
+	return lastError, false
 }
 
 // Stop recorder


### PR DESCRIPTION
This `PR` enables the recorder to send big payloads in batches. Currently the max spans per batch is hardcoded to 1000.

In a test with *20101* spans, this is the log output:

```
2020/02/14 00:09:46 agent.go:202: environment variable $SCOPE_DSN not found
2020/02/14 00:09:46 agent.go:210: API key found in the native app configuration
2020/02/14 00:09:46 agent.go:223: API endpoint found in the native app configuration
2020/02/14 00:09:47 recorder.go:149: sending 9 spans in 1 batches
2020/02/14 00:09:47 ntp.go:44: ntp offset: 5.316149ms
2020/02/14 00:09:48 recorder.go:149: sending 7 spans in 1 batches
2020/02/14 00:09:50 recorder.go:149: sending 5 spans in 1 batches
2020/02/14 00:09:51 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:09:52 recorder.go:149: sending 1 spans in 1 batches
2020/02/14 00:09:53 recorder.go:149: sending 7 spans in 1 batches
2020/02/14 00:09:54 recorder.go:149: sending 3 spans in 1 batches
2020/02/14 00:09:55 recorder.go:149: sending 5 spans in 1 batches
2020/02/14 00:09:56 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:09:57 recorder.go:149: sending 3 spans in 1 batches
2020/02/14 00:09:58 recorder.go:149: sending 5 spans in 1 batches
2020/02/14 00:09:59 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:00 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:01 recorder.go:149: sending 6 spans in 1 batches
2020/02/14 00:10:02 recorder.go:149: sending 0 spans in 1 batches
2020/02/14 00:10:03 recorder.go:149: sending 3 spans in 1 batches
2020/02/14 00:10:04 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:05 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:06 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:07 recorder.go:149: sending 2 spans in 1 batches
2020/02/14 00:10:08 recorder.go:149: sending 3 spans in 1 batches
2020/02/14 00:10:09 recorder.go:149: sending 3 spans in 1 batches
2020/02/14 00:10:10 recorder.go:149: sending 4 spans in 1 batches
2020/02/14 00:10:11 recorder.go:149: sending 1 spans in 1 batches
2020/02/14 00:10:12 recorder.go:149: sending 213 spans in 1 batches
2020/02/14 00:10:14 recorder.go:149: sending 2040 spans in 3 batches
2020/02/14 00:10:14 recorder.go:176: sending batch 1 with 1000 spans
2020/02/14 00:10:21 recorder.go:176: sending batch 2 with 1000 spans
2020/02/14 00:10:30 recorder.go:176: sending batch 3 with 40 spans
2020/02/14 00:10:30 agent.go:356: Scope agent is stopping gracefully...
2020/02/14 00:10:31 recorder.go:149: sending 17753 spans in 18 batches
2020/02/14 00:10:31 recorder.go:176: sending batch 1 with 1000 spans
2020/02/14 00:10:39 recorder.go:176: sending batch 2 with 1000 spans
2020/02/14 00:10:46 recorder.go:176: sending batch 3 with 1000 spans
2020/02/14 00:10:53 recorder.go:176: sending batch 4 with 1000 spans
2020/02/14 00:11:00 recorder.go:176: sending batch 5 with 1000 spans
2020/02/14 00:11:07 recorder.go:176: sending batch 6 with 1000 spans
2020/02/14 00:11:14 recorder.go:176: sending batch 7 with 1000 spans
2020/02/14 00:11:21 recorder.go:176: sending batch 8 with 1000 spans
2020/02/14 00:11:28 recorder.go:176: sending batch 9 with 1000 spans
2020/02/14 00:11:35 recorder.go:176: sending batch 10 with 1000 spans
2020/02/14 00:11:46 recorder.go:176: sending batch 11 with 1000 spans
2020/02/14 00:11:53 recorder.go:176: sending batch 12 with 1000 spans
2020/02/14 00:12:02 recorder.go:176: sending batch 13 with 1000 spans
2020/02/14 00:12:10 recorder.go:176: sending batch 14 with 1000 spans
2020/02/14 00:12:17 recorder.go:176: sending batch 15 with 1000 spans
2020/02/14 00:12:24 recorder.go:176: sending batch 16 with 1000 spans
2020/02/14 00:12:31 recorder.go:176: sending batch 17 with 1000 spans
2020/02/14 00:12:37 recorder.go:176: sending batch 18 with 753 spans
```

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/69803/74487321-7660d900-4ebf-11ea-9a4e-e6df794e4143.png">

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/69803/74487382-9d1f0f80-4ebf-11ea-907d-6406e6424665.png">
