### PR TITLE
Fixes panic handling of the agent runner

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -384,6 +384,10 @@ func (a *Agent) Stop() {
 	a.PrintReport()
 }
 
+func (a *Agent) IsPanicAsFail() bool {
+	return a.panicAsFail
+}
+
 func generateAgentID() string {
 	agentId, err := uuid.NewRandom()
 	if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -392,10 +392,6 @@ func (a *Agent) Stop() {
 	a.PrintReport()
 }
 
-func (a *Agent) IsPanicAsFail() bool {
-	return a.panicAsFail
-}
-
 func generateAgentID() string {
 	agentId, err := uuid.NewRandom()
 	if err != nil {

--- a/init.go
+++ b/init.go
@@ -30,15 +30,6 @@ func Run(m *testing.M, opts ...agent.Option) int {
 	logging.PatchStandardLogger()
 
 	scopetesting.Init(m)
-	scopetesting.SetDefaultPanicHandler(func(test *scopetesting.Test) {
-		if defaultAgent.IsPanicAsFail() {
-			return
-		}
-		instrumentation.Logger().Printf("test '%s' has panicked, stopping agent", test.Name())
-		if defaultAgent != nil {
-			defaultAgent.Stop()
-		}
-	})
 
 	// Handle SIGINT and SIGTERM
 	sigs := make(chan os.Signal, 1)

--- a/init.go
+++ b/init.go
@@ -31,6 +31,9 @@ func Run(m *testing.M, opts ...agent.Option) int {
 
 	scopetesting.Init(m)
 	scopetesting.SetDefaultPanicHandler(func(test *scopetesting.Test) {
+		if defaultAgent.IsPanicAsFail() {
+			return
+		}
 		instrumentation.Logger().Printf("test '%s' has panicked, stopping agent", test.Name())
 		if defaultAgent != nil {
 			defaultAgent.Stop()

--- a/instrumentation/testing/coverage.go
+++ b/instrumentation/testing/coverage.go
@@ -88,8 +88,7 @@ func startCoverage() {
 	for name, counts := range cover.Counters {
 		counters[name] = make([]uint32, len(counts))
 		for i := range counts {
-			counters[name][i] = atomic.LoadUint32(&counts[i])
-			counts[i] = 0
+			counters[name][i] = atomic.SwapUint32(&counts[i], 0)
 		}
 	}
 }

--- a/instrumentation/testing/init.go
+++ b/instrumentation/testing/init.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"reflect"
-	"sync"
 	"testing"
 
 	"go.undefinedlabs.com/scopeagent/reflection"
@@ -44,23 +43,4 @@ func Init(m *testing.M) {
 		}
 		*intBenchmarks = benchmarks
 	}
-}
-
-func getTestMutex(t *testing.T) *sync.RWMutex {
-	if ptr, err := reflection.GetFieldPointerOf(t, "mu"); err == nil {
-		return (*sync.RWMutex)(ptr)
-	}
-	return nil
-}
-
-func getIsParallel(t *testing.T) bool {
-	mu := getTestMutex(t)
-	if mu != nil {
-		mu.Lock()
-		defer mu.Unlock()
-	}
-	if pointer, err := reflection.GetFieldPointerOf(t, "isParallel"); err == nil {
-		return *(*bool)(pointer)
-	}
-	return false
 }

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -18,6 +18,7 @@ import (
 	"go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/instrumentation/logging"
+	"go.undefinedlabs.com/scopeagent/reflection"
 	"go.undefinedlabs.com/scopeagent/runner"
 	"go.undefinedlabs.com/scopeagent/tags"
 )
@@ -161,7 +162,7 @@ func (test *Test) end() {
 	}
 
 	// Checks if the current test is running parallel to extract the coverage or not
-	if getIsParallel(test.t) {
+	if reflection.GetIsParallel(test.t) {
 		instrumentation.Logger().Printf("CodePath in parallel test is not supported: %v\n", test.t.Name())
 		restoreCoverageCounters()
 	} else {

--- a/reflection/reflect.go
+++ b/reflection/reflect.go
@@ -3,6 +3,8 @@ package reflection
 import (
 	"errors"
 	"reflect"
+	"sync"
+	"testing"
 	"unsafe"
 )
 
@@ -24,4 +26,23 @@ func GetFieldPointerOf(i interface{}, fieldName string) (unsafe.Pointer, error) 
 		return ptrToY, nil
 	}
 	return nil, errors.New("field can't be retrieved")
+}
+
+func GetTestMutex(t *testing.T) *sync.RWMutex {
+	if ptr, err := GetFieldPointerOf(t, "mu"); err == nil {
+		return (*sync.RWMutex)(ptr)
+	}
+	return nil
+}
+
+func GetIsParallel(t *testing.T) bool {
+	mu := GetTestMutex(t)
+	if mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	if pointer, err := GetFieldPointerOf(t, "isParallel"); err == nil {
+		return *(*bool)(pointer)
+	}
+	return false
 }

--- a/runner/main.go
+++ b/runner/main.go
@@ -51,6 +51,9 @@ func GetOriginalTestName(name string) string {
 
 // Runs a test suite
 func Run(m *testing.M, options Options) int {
+	if options.FailRetries == 0 && !options.PanicAsFail {
+		return m.Run()
+	}
 	if options.Logger == nil {
 		options.Logger = log.New(ioutil.Discard, "", 0)
 	}

--- a/runner/main.go
+++ b/runner/main.go
@@ -124,7 +124,7 @@ func (td *testDescriptor) run(t *testing.T) {
 				innerTest = gt
 				td.test.F(gt)
 			})
-			if getIsParallel(innerTest) && !getIsParallel(t) {
+			if reflection.GetIsParallel(innerTest) && !reflection.GetIsParallel(t) {
 				t.Parallel()
 			}
 		})
@@ -192,16 +192,9 @@ func (td *testDescriptor) refreshGlobalFailedFlag(t *testing.T) {
 	}
 }
 
-func getTestMutex(t *testing.T) *sync.RWMutex {
-	if ptr, err := reflection.GetFieldPointerOf(t, "mu"); err == nil {
-		return (*sync.RWMutex)(ptr)
-	}
-	return nil
-}
-
 // Sets the test failure flag
 func setTestFailureFlag(t *testing.T, value bool) {
-	mu := getTestMutex(t)
+	mu := reflection.GetTestMutex(t)
 	if mu != nil {
 		mu.Lock()
 		defer mu.Unlock()
@@ -214,7 +207,7 @@ func setTestFailureFlag(t *testing.T, value bool) {
 
 // Gets the parent from a test
 func getTestParent(t *testing.T) *testing.T {
-	mu := getTestMutex(t)
+	mu := reflection.GetTestMutex(t)
 	if mu != nil {
 		mu.RLock()
 		defer mu.RUnlock()
@@ -231,7 +224,7 @@ func getTestParent(t *testing.T) *testing.T {
 
 // Sets the chatty flag
 func setChattyFlag(t *testing.T, value bool) {
-	mu := getTestMutex(t)
+	mu := reflection.GetTestMutex(t)
 	if mu != nil {
 		mu.Lock()
 		defer mu.Unlock()
@@ -244,7 +237,7 @@ func setChattyFlag(t *testing.T, value bool) {
 
 // Sets the test name
 func setTestName(t *testing.T, value string) {
-	mu := getTestMutex(t)
+	mu := reflection.GetTestMutex(t)
 	if mu != nil {
 		mu.Lock()
 		defer mu.Unlock()
@@ -253,16 +246,4 @@ func setTestName(t *testing.T, value string) {
 	if ptr, err := reflection.GetFieldPointerOf(t, "name"); err == nil {
 		*(*string)(ptr) = value
 	}
-}
-
-func getIsParallel(t *testing.T) bool {
-	mu := getTestMutex(t)
-	if mu != nil {
-		mu.Lock()
-		defer mu.Unlock()
-	}
-	if pointer, err := reflection.GetFieldPointerOf(t, "isParallel"); err == nil {
-		return *(*bool)(pointer)
-	}
-	return false
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 var (
@@ -89,4 +90,42 @@ func TestFailSubTest(t *testing.T) {
 		failSubTest++
 		t.Fatal("Subtest fail")
 	})
+}
+
+func TestParallelPass(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 10; i++ {
+		t.Run("child", func(t *testing.T) {
+			t.Parallel()
+		})
+	}
+
+	<-time.After(1 * time.Second)
+}
+
+func TestParallelFail(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 10; i++ {
+		t.Run("child", func(t *testing.T) {
+			t.Parallel()
+		})
+	}
+
+	<-time.After(1 * time.Second)
+	t.FailNow()
+}
+
+func TestParallelPanic(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 10; i++ {
+		t.Run("child", func(t *testing.T) {
+			t.Parallel()
+		})
+	}
+
+	<-time.After(1 * time.Second)
+	panic("forced parallel test panic")
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -14,7 +14,14 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	Run(m, true, 4, nil)
+	Run(m, Options{
+		FailRetries: 4,
+		PanicAsFail: true,
+		Logger:      nil,
+		OnPanic: func(t *testing.T, err error) {
+			fmt.Printf("the test '%s' has paniked with error: %s", t.Name(), err)
+		},
+	})
 	fmt.Println(okCount, failCount, errorCount, flakyCount, failSubTest)
 	if okCount != 1 {
 		panic("TestOk ran an unexpected number of times")


### PR DESCRIPTION
- Fixes panic handling of the agent runner: Currently with the recorder refactor, when we handle panics as a failure in the runner, the instrumentation panic handler is called and the recorder get stopped, so new retries are no recorded. This only happens when a test panic and the .WithPanicAsFail() option is enabled.

- Removes unnecessary lock: This locks are no longer necessary because the run method is never called from different threads.