### PR TITLE
Fix race condition on tilde expand

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -296,7 +296,6 @@ func NewAgent(options ...Option) (*Agent, error) {
 			agent.testingMode = agent.metadata[tags.CI].(bool)
 		}
 	}
-	agent.SetTestingMode(agent.testingMode)
 
 	if agent.failRetriesCount == 0 {
 		agent.failRetriesCount = env.ScopeTestingFailRetries.Value
@@ -317,6 +316,7 @@ func NewAgent(options ...Option) (*Agent, error) {
 		// Log the error in the current span
 		OnSpanFinishPanic: scopeError.LogErrorInRawSpan,
 	})
+	agent.SetTestingMode(agent.testingMode)
 	instrumentation.SetTracer(agent.tracer)
 	instrumentation.SetLogger(agent.logger)
 	if agent.setGlobalTracer || env.ScopeTracerGlobal.Value {

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )


### PR DESCRIPTION
This fixes the race condition over the metadata map.

**Explanation:**
We create an span recorder in the agent.go file and after we access to the metadata map. Meanwhile the recorder has a go routine which access the metadata map and serialize it into the payload.

**Solution:**
We move all access to the metadata map before creating the span recorder, also we create the agentId field in the recorder to avoid accessing the map.