### PR TITLE
SetTestingMode refactor

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -306,7 +306,11 @@ func NewAgent(options ...Option) (*Agent, error) {
 		agent.logMetadata()
 	}
 
-	agent.recorder = NewSpanRecorder(agent)
+	flushFrequency := nonTestingModeFrequency
+	if agent.testingMode {
+		flushFrequency = testingModeFrequency
+	}
+	agent.recorder = NewSpanRecorder(agent, flushFrequency)
 	agent.tracer = tracer.NewWithOptions(tracer.Options{
 		Recorder: agent.recorder,
 		ShouldSample: func(traceID uint64) bool {
@@ -316,7 +320,6 @@ func NewAgent(options ...Option) (*Agent, error) {
 		// Log the error in the current span
 		OnSpanFinishPanic: scopeError.LogErrorInRawSpan,
 	})
-	agent.SetTestingMode(agent.testingMode)
 	instrumentation.SetTracer(agent.tracer)
 	instrumentation.SetLogger(agent.logger)
 	if agent.setGlobalTracer || env.ScopeTracerGlobal.Value {
@@ -341,15 +344,6 @@ func (a *Agent) setupLogging() error {
 
 	a.logger = log.New(file, "", log.LstdFlags|log.Lshortfile)
 	return nil
-}
-
-func (a *Agent) SetTestingMode(enabled bool) {
-	a.testingMode = enabled
-	if a.testingMode {
-		a.recorder.ChangeFlushFrequency(testingModeFrequency)
-	} else {
-		a.recorder.ChangeFlushFrequency(nonTestingModeFrequency)
-	}
 }
 
 func (a *Agent) Tracer() opentracing.Tracer {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -44,6 +44,7 @@ type (
 
 		recorder         *SpanRecorder
 		recorderFilename string
+		flushFrequency   time.Duration
 
 		userAgent string
 		agentType string
@@ -306,11 +307,11 @@ func NewAgent(options ...Option) (*Agent, error) {
 		agent.logMetadata()
 	}
 
-	flushFrequency := nonTestingModeFrequency
+	agent.flushFrequency = nonTestingModeFrequency
 	if agent.testingMode {
-		flushFrequency = testingModeFrequency
+		agent.flushFrequency = testingModeFrequency
 	}
-	agent.recorder = NewSpanRecorder(agent, flushFrequency)
+	agent.recorder = NewSpanRecorder(agent)
 	agent.tracer = tracer.NewWithOptions(tracer.Options{
 		Recorder: agent.recorder,
 		ShouldSample: func(traceID uint64) bool {

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -65,7 +65,7 @@ type (
 	}
 )
 
-func NewSpanRecorder(agent *Agent, flushFrequency time.Duration) *SpanRecorder {
+func NewSpanRecorder(agent *Agent) *SpanRecorder {
 	r := new(SpanRecorder)
 	r.agentId = agent.agentId
 	r.apiEndpoint = agent.apiEndpoint
@@ -75,7 +75,7 @@ func NewSpanRecorder(agent *Agent, flushFrequency time.Duration) *SpanRecorder {
 	r.debugMode = agent.debugMode
 	r.metadata = agent.metadata
 	r.logger = agent.logger
-	r.flushFrequency = flushFrequency
+	r.flushFrequency = agent.flushFrequency
 	r.url = agent.getUrl("api/agent/ingest")
 	r.client = &http.Client{}
 	r.stats = &RecorderStats{}
@@ -96,12 +96,6 @@ func (r *SpanRecorder) RecordSpan(span tracer.RawSpan) {
 		return
 	}
 	r.addSpan(span)
-}
-
-func (r *SpanRecorder) ChangeFlushFrequency(frequency time.Duration) {
-	r.Lock()
-	defer r.Unlock()
-	r.flushFrequency = frequency
 }
 
 func (r *SpanRecorder) loop() error {

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -65,7 +65,7 @@ type (
 	}
 )
 
-func NewSpanRecorder(agent *Agent) *SpanRecorder {
+func NewSpanRecorder(agent *Agent, flushFrequency time.Duration) *SpanRecorder {
 	r := new(SpanRecorder)
 	r.agentId = agent.agentId
 	r.apiEndpoint = agent.apiEndpoint
@@ -75,7 +75,7 @@ func NewSpanRecorder(agent *Agent) *SpanRecorder {
 	r.debugMode = agent.debugMode
 	r.metadata = agent.metadata
 	r.logger = agent.logger
-	r.flushFrequency = time.Minute
+	r.flushFrequency = flushFrequency
 	r.url = agent.getUrl("api/agent/ingest")
 	r.client = &http.Client{}
 	r.stats = &RecorderStats{}

--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,10 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )


### PR DESCRIPTION
Related to: https://github.com/undefinedlabs/scope-go-agent/pull/162#discussion_r380320314

Removes the `SetTestingMode` api, and adds `flushFrequency` param in NewSpanRecorder

The span recorder has no notion of `testing` but has notion of `flushFrequency` so we calculate the frequency before calling the `NewSpanRecorder` func