### PR TITLE
Improves panic reports to scope and fixes source field on events

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -296,7 +296,7 @@ func NewAgent(options ...Option) (*Agent, error) {
 	if sRoot, ok := agent.metadata[tags.SourceRoot]; ok {
 		cSRoot := sRoot.(string)
 		cSRoot = filepath.Clean(cSRoot)
-		if sRootEx, err := homedir.Expand(sRoot.(string)); err == nil {
+		if sRootEx, err := homedir.Expand(cSRoot); err == nil {
 			sourceRoot = sRootEx
 			agent.metadata[tags.SourceRoot] = sRootEx
 		}
@@ -355,7 +355,7 @@ func (a *Agent) setupLogging() error {
 	if err != nil {
 		return err
 	}
-	a.recorderFilename = path.Join(dir, filename)
+	a.recorderFilename = filepath.Join(dir, filename)
 
 	file, err := os.OpenFile(a.recorderFilename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
@@ -445,7 +445,7 @@ func getLogPath() (string, error) {
 	}
 
 	// If the log folder can't be used we return a temporal path, so we don't miss the agent logs
-	logFolder = path.Join(os.TempDir(), "scope")
+	logFolder = filepath.Join(os.TempDir(), "scope")
 	if _, err := os.Stat(logFolder); err == nil {
 		return logFolder, nil
 	} else if os.IsNotExist(err) && os.Mkdir(logFolder, 0755) == nil {

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"context"
 	"fmt"
-	"go.undefinedlabs.com/scopeagent/tags"
 	"path"
 	"path/filepath"
 	"strings"
@@ -59,7 +58,6 @@ func WriteExceptionEventInRawSpan(rawSpan *tracer.RawSpan, err **errors.Error) {
 			Timestamp: time.Now(),
 			Fields:    exceptionFields,
 		})
-		rawSpan.Tags["error"] = true
 		*err = markSpanAsError
 	}
 }
@@ -117,29 +115,6 @@ func GetCurrentStackTrace(skip int) map[string]interface{} {
 // Get the current error with the fixed stacktrace
 func GetCurrentError(recoverData interface{}) *errors.Error {
 	return errors.Wrap(recoverData, 1)
-}
-
-// Gets the current stack frames array
-func GetCurrentStackFrames(skip int) []StackFrames {
-	skip = skip + 1
-	err := errors.New(nil)
-	errStack := err.StackFrames()
-	nLength := len(errStack) - skip
-	if nLength < 0 {
-		return nil
-	}
-	stackFrames := make([]StackFrames, nLength)
-	for idx, frame := range errStack {
-		if idx >= skip {
-			stackFrames[idx-skip] = StackFrames{
-				File:       frame.File,
-				LineNumber: frame.LineNumber,
-				Name:       frame.Name,
-				Package:    frame.Package,
-			}
-		}
-	}
-	return stackFrames
 }
 
 func getExceptionLogFields(eventType string, recoverData interface{}, skipFrames int) []log.Field {

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -49,9 +49,8 @@ func WriteExceptionEventInRawSpan(rawSpan *tracer.RawSpan, err **errors.Error) {
 	if rawSpan.Tags == nil {
 		rawSpan.Tags = opentracing.Tags{}
 	}
-	if *err == markSpanAsError {
-		rawSpan.Tags["error"] = true
-	} else {
+	rawSpan.Tags["error"] = true
+	if *err != markSpanAsError {
 		var exceptionFields = getExceptionLogFields("error", *err, 1)
 		if rawSpan.Logs == nil {
 			rawSpan.Logs = []opentracing.LogRecord{}

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -119,6 +119,29 @@ func GetCurrentError(recoverData interface{}) *errors.Error {
 	return errors.Wrap(recoverData, 1)
 }
 
+// Gets the current stack frames array
+func GetCurrentStackFrames(skip int) []StackFrames {
+	skip = skip + 1
+	err := errors.New(nil)
+	errStack := err.StackFrames()
+	nLength := len(errStack) - skip
+	if nLength < 0 {
+		return nil
+	}
+	stackFrames := make([]StackFrames, nLength)
+	for idx, frame := range errStack {
+		if idx >= skip {
+			stackFrames[idx-skip] = StackFrames{
+				File:       frame.File,
+				LineNumber: frame.LineNumber,
+				Name:       frame.Name,
+				Package:    frame.Package,
+			}
+		}
+	}
+	return stackFrames
+}
+
 func getExceptionLogFields(eventType string, recoverData interface{}, skipFrames int) []log.Field {
 	if recoverData != nil {
 		err := errors.Wrap(recoverData, 2+skipFrames)

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"context"
 	"fmt"
+	"go.undefinedlabs.com/scopeagent/tags"
 	"path"
 	"path/filepath"
 	"strings"

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -128,7 +127,7 @@ func getExceptionLogFields(eventType string, recoverData interface{}, skipFrames
 		if errStack != nil && len(errStack) > 0 {
 			sourceRoot := instrumentation.GetSourceRoot()
 			for _, currentFrame := range errStack {
-				dir := path.Dir(currentFrame.File)
+				dir := filepath.Dir(currentFrame.File)
 				if strings.Index(dir, sourceRoot) != -1 {
 					source = fmt.Sprintf("%s:%d", currentFrame.File, currentFrame.LineNumber)
 					break

--- a/instrumentation/nethttp/server.go
+++ b/instrumentation/nethttp/server.go
@@ -181,9 +181,7 @@ func middlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 			}
 
 			if r := recover(); r != nil {
-				if r != errors.MarkSpanAsError {
-					errors.LogError(sp, r, 1)
-				}
+				errors.WriteExceptionEvent(sp, r, 1)
 				sp.Finish()
 				panic(r)
 			}

--- a/instrumentation/testing/tb.go
+++ b/instrumentation/testing/tb.go
@@ -2,12 +2,14 @@ package testing
 
 import (
 	"fmt"
+	"path/filepath"
+	"runtime"
+
 	"github.com/opentracing/opentracing-go/log"
+
 	"go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/tags"
-	"path/filepath"
-	"runtime"
 )
 
 // ***************************

--- a/instrumentation/testing/tb.go
+++ b/instrumentation/testing/tb.go
@@ -3,6 +3,8 @@ package testing
 import (
 	"fmt"
 	"github.com/opentracing/opentracing-go/log"
+	"go.undefinedlabs.com/scopeagent/errors"
+	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/tags"
 	"path/filepath"
 	"runtime"
@@ -217,15 +219,19 @@ func (test *Test) Helper() {
 	test.t.Helper()
 }
 
+// Log panic data with stacktrace
+func (test *Test) LogPanic(recoverData interface{}, skipFrames int) {
+	errors.LogPanic(test.ctx, recoverData, skipFrames+1)
+}
+
 func getSourceFileAndNumber() string {
 	var source string
-	if pc, file, line, ok := runtime.Caller(2); ok == true {
+	if pc, file, line, ok := instrumentation.GetCallerInsideSourceRoot(2); ok == true {
 		pcEntry := runtime.FuncForPC(pc).Entry()
 		// Try to detect the patch function
 		if isAPatchPointer(pcEntry) {
 			// The monkey patching version adds 4 frames to the stack.
-			if _, file, line, ok := runtime.Caller(6); ok == true {
-				file = filepath.Clean(file)
+			if _, file, line, ok := instrumentation.GetCallerInsideSourceRoot(6); ok == true {
 				source = fmt.Sprintf("%s:%d", file, line)
 			}
 		} else {

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -259,8 +259,7 @@ func PanicAllRunningTests(e interface{}, skip int) {
 	for _, v := range tmp {
 		delete(autoInstrumentedTests, v.t)
 		v.t.Fail()
-		v.span.SetTag("error", true)
-		errors.LogError(v.span, e, 1+skip)
+		errors.WriteExceptionEvent(v.span, e, 1+skip)
 		v.end()
 	}
 }

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -172,10 +172,7 @@ func (test *Test) end() {
 
 	if r := recover(); r != nil {
 		test.span.SetTag("test.status", tags.TestStatus_FAIL)
-		test.span.SetTag("error", true)
-		if r != errors.MarkSpanAsError {
-			errors.LogError(test.span, r, 1)
-		}
+		errors.WriteExceptionEvent(test.span, r, 1)
 		test.span.FinishWithOptions(finishOptions)
 		panic(r)
 	}

--- a/instrumentation/tracer.go
+++ b/instrumentation/tracer.go
@@ -4,12 +4,16 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"log"
+	"path"
+	"runtime"
+	"strings"
 	"sync"
 )
 
 var (
-	tracer opentracing.Tracer = opentracing.NoopTracer{}
-	logger                    = log.New(ioutil.Discard, "", 0)
+	tracer     opentracing.Tracer = opentracing.NoopTracer{}
+	logger                        = log.New(ioutil.Discard, "", 0)
+	sourceRoot                    = ""
 
 	m sync.RWMutex
 )
@@ -40,4 +44,37 @@ func Logger() *log.Logger {
 	defer m.RUnlock()
 
 	return logger
+}
+
+func SetSourceRoot(root string) {
+	m.Lock()
+	defer m.Unlock()
+
+	sourceRoot = root
+}
+
+func GetSourceRoot() string {
+	m.RLock()
+	defer m.RUnlock()
+
+	return sourceRoot
+}
+
+//go:noinline
+func GetCallerInsideSourceRoot(skip int) (pc uintptr, file string, line int, ok bool) {
+	pcs := make([]uintptr, 64)
+	count := runtime.Callers(skip+2, pcs)
+	pcs = pcs[0:count]
+	frames := runtime.CallersFrames(pcs)
+	for {
+		frame, more := frames.Next()
+		dir := path.Dir(frame.File)
+		if strings.Index(dir, sourceRoot) != -1 {
+			return frame.PC, frame.File, frame.Line, true
+		}
+		if !more {
+			break
+		}
+	}
+	return
 }

--- a/instrumentation/tracer.go
+++ b/instrumentation/tracer.go
@@ -1,13 +1,14 @@
 package instrumentation
 
 import (
-	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"log"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/opentracing/opentracing-go"
 )
 
 var (
@@ -68,9 +69,10 @@ func GetCallerInsideSourceRoot(skip int) (pc uintptr, file string, line int, ok 
 	frames := runtime.CallersFrames(pcs)
 	for {
 		frame, more := frames.Next()
-		dir := path.Dir(frame.File)
+		file := filepath.Clean(frame.File)
+		dir := filepath.Dir(file)
 		if strings.Index(dir, sourceRoot) != -1 {
-			return frame.PC, frame.File, frame.Line, true
+			return frame.PC, file, frame.Line, true
 		}
 		if !more {
 			break


### PR DESCRIPTION
Closes #166 

This `PR` improves support for panic data report in spans with stacktraces (as a log or as an exception) and fixes the source field of the events, to always reference a file inside the source root.