### PR TITLE
Recorder buffer refactor

### DIFF
--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -147,9 +147,6 @@ func (r *SpanRecorder) sendSpans() (error, bool) {
 	for {
 		spans, spMore, spTotal := r.takePayloadSpan(batchSize)
 		events, evMore, evTotal := r.takePayloadEvents(batchSize)
-		if len(spans) == 0 && len(events) == 0 {
-			break
-		}
 
 		payload := map[string]interface{}{
 			"metadata":   r.metadata,

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -145,8 +145,8 @@ func (r *SpanRecorder) sendSpans() (error, bool) {
 	const batchSize = 1000
 	var lastError error
 	for {
-		spans, spMore, spTotal := r.takePayloadSpan(batchSize)
-		events, evMore, evTotal := r.takePayloadEvents(batchSize)
+		spans, spMore, spTotal := r.popPayloadSpan(batchSize)
+		events, evMore, evTotal := r.popPayloadEvents(batchSize)
 
 		payload := map[string]interface{}{
 			"metadata":   r.metadata,
@@ -378,8 +378,8 @@ func (r *SpanRecorder) hasPayloadData() bool {
 	return len(r.payloadSpans) > 0 || len(r.payloadEvents) > 0
 }
 
-// Take a number of payload spans from buffer
-func (r *SpanRecorder) takePayloadSpan(count int) ([]PayloadSpan, bool, int) {
+// Gets a number of payload spans from buffer
+func (r *SpanRecorder) popPayloadSpan(count int) ([]PayloadSpan, bool, int) {
 	r.Lock()
 	defer r.Unlock()
 	var spans []PayloadSpan
@@ -397,8 +397,8 @@ func (r *SpanRecorder) takePayloadSpan(count int) ([]PayloadSpan, bool, int) {
 	return spans, true, length
 }
 
-// Take a number of payload events from buffer
-func (r *SpanRecorder) takePayloadEvents(count int) ([]PayloadEvent, bool, int) {
+// Gets a number of payload events from buffer
+func (r *SpanRecorder) popPayloadEvents(count int) ([]PayloadEvent, bool, int) {
 	r.Lock()
 	defer r.Unlock()
 	var events []PayloadEvent

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -392,7 +392,7 @@ func (r *SpanRecorder) takePayloadSpan(count int) ([]PayloadSpan, bool, int) {
 		if spans == nil {
 			spans = make([]PayloadSpan, 0)
 		}
-		r.payloadSpans = make([]PayloadSpan, 0)
+		r.payloadSpans = nil
 		return spans, false, length
 	}
 	spans = r.payloadSpans[:count]
@@ -411,7 +411,7 @@ func (r *SpanRecorder) takePayloadEvents(count int) ([]PayloadEvent, bool, int) 
 		if events == nil {
 			events = make([]PayloadEvent, 0)
 		}
-		r.payloadEvents = make([]PayloadEvent, 0)
+		r.payloadEvents = nil
 		return events, false, length
 	}
 	events = r.payloadEvents[:count]

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,13 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,10 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 // indirect
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )


### PR DESCRIPTION
Closes #171 

This `PR` split the current recorder buffer to spans and events, allowing to send a max number of each type in every payload.

**Example:**
```
2020/02/25 10:13:43 agent.go:210: environment variable $SCOPE_DSN not found
2020/02/25 10:13:43 agent.go:218: API key found in the native app configuration
2020/02/25 10:13:43 agent.go:231: API endpoint found in the native app configuration
2020/02/25 10:13:43 ntp.go:44: ntp offset: 6.940212ms
2020/02/25 10:13:44 recorder.go:174: sending 1000/2007 spans with 1000/10035 events
2020/02/25 10:13:52 agent.go:391: Scope agent is stopping gracefully...
2020/02/25 10:13:53 recorder.go:174: sending 1000/19101 spans with 1000/99505 events
2020/02/25 10:14:06 recorder.go:174: sending 1000/18101 spans with 1000/98505 events
2020/02/25 10:14:17 recorder.go:174: sending 1000/17101 spans with 1000/97505 events
2020/02/25 10:14:28 recorder.go:174: sending 1000/16101 spans with 1000/96505 events
2020/02/25 10:14:38 recorder.go:174: sending 1000/15101 spans with 1000/95505 events
2020/02/25 10:14:49 recorder.go:174: sending 1000/14101 spans with 1000/94505 events
2020/02/25 10:14:59 recorder.go:174: sending 1000/13101 spans with 1000/93505 events
2020/02/25 10:15:08 recorder.go:174: sending 1000/12101 spans with 1000/92505 events
2020/02/25 10:15:19 recorder.go:174: sending 1000/11101 spans with 1000/91505 events
2020/02/25 10:15:29 recorder.go:174: sending 1000/10101 spans with 1000/90505 events
2020/02/25 10:15:37 recorder.go:174: sending 1000/9101 spans with 1000/89505 events
2020/02/25 10:15:48 recorder.go:174: sending 1000/8101 spans with 1000/88505 events
2020/02/25 10:15:57 recorder.go:174: sending 1000/7101 spans with 1000/87505 events
2020/02/25 10:16:07 recorder.go:174: sending 1000/6101 spans with 1000/86505 events
2020/02/25 10:16:18 recorder.go:174: sending 1000/5101 spans with 1000/85505 events
2020/02/25 10:16:27 recorder.go:174: sending 1000/4101 spans with 1000/84505 events
2020/02/25 10:16:37 recorder.go:174: sending 1000/3101 spans with 1000/83505 events
2020/02/25 10:16:47 recorder.go:174: sending 1000/2101 spans with 1000/82505 events
2020/02/25 10:16:57 recorder.go:174: sending 1000/1101 spans with 1000/81505 events
2020/02/25 10:17:07 recorder.go:174: sending 101/101 spans with 1000/80505 events
2020/02/25 10:17:08 recorder.go:174: sending 0/0 spans with 1000/79505 events
2020/02/25 10:17:09 recorder.go:174: sending 0/0 spans with 1000/78505 events
2020/02/25 10:17:10 recorder.go:174: sending 0/0 spans with 1000/77505 events
2020/02/25 10:17:11 recorder.go:174: sending 0/0 spans with 1000/76505 events
2020/02/25 10:17:12 recorder.go:174: sending 0/0 spans with 1000/75505 events
2020/02/25 10:17:12 recorder.go:174: sending 0/0 spans with 1000/74505 events
2020/02/25 10:17:13 recorder.go:174: sending 0/0 spans with 1000/73505 events
2020/02/25 10:17:14 recorder.go:174: sending 0/0 spans with 1000/72505 events
2020/02/25 10:17:15 recorder.go:174: sending 0/0 spans with 1000/71505 events
2020/02/25 10:17:16 recorder.go:174: sending 0/0 spans with 1000/70505 events
2020/02/25 10:17:17 recorder.go:174: sending 0/0 spans with 1000/69505 events
2020/02/25 10:17:17 recorder.go:174: sending 0/0 spans with 1000/68505 events
2020/02/25 10:17:18 recorder.go:174: sending 0/0 spans with 1000/67505 events
2020/02/25 10:17:19 recorder.go:174: sending 0/0 spans with 1000/66505 events
2020/02/25 10:17:20 recorder.go:174: sending 0/0 spans with 1000/65505 events
2020/02/25 10:17:20 recorder.go:174: sending 0/0 spans with 1000/64505 events
2020/02/25 10:17:21 recorder.go:174: sending 0/0 spans with 1000/63505 events
2020/02/25 10:17:22 recorder.go:174: sending 0/0 spans with 1000/62505 events
2020/02/25 10:17:23 recorder.go:174: sending 0/0 spans with 1000/61505 events
2020/02/25 10:17:24 recorder.go:174: sending 0/0 spans with 1000/60505 events
2020/02/25 10:17:24 recorder.go:174: sending 0/0 spans with 1000/59505 events
2020/02/25 10:17:25 recorder.go:174: sending 0/0 spans with 1000/58505 events
2020/02/25 10:17:26 recorder.go:174: sending 0/0 spans with 1000/57505 events
2020/02/25 10:17:27 recorder.go:174: sending 0/0 spans with 1000/56505 events
2020/02/25 10:17:28 recorder.go:174: sending 0/0 spans with 1000/55505 events
2020/02/25 10:17:29 recorder.go:174: sending 0/0 spans with 1000/54505 events
2020/02/25 10:17:30 recorder.go:174: sending 0/0 spans with 1000/53505 events
2020/02/25 10:17:31 recorder.go:174: sending 0/0 spans with 1000/52505 events
2020/02/25 10:17:32 recorder.go:174: sending 0/0 spans with 1000/51505 events
2020/02/25 10:17:33 recorder.go:174: sending 0/0 spans with 1000/50505 events
2020/02/25 10:17:35 recorder.go:174: sending 0/0 spans with 1000/49505 events
2020/02/25 10:17:35 recorder.go:174: sending 0/0 spans with 1000/48505 events
2020/02/25 10:17:36 recorder.go:174: sending 0/0 spans with 1000/47505 events
2020/02/25 10:17:37 recorder.go:174: sending 0/0 spans with 1000/46505 events
2020/02/25 10:17:38 recorder.go:174: sending 0/0 spans with 1000/45505 events
2020/02/25 10:17:39 recorder.go:174: sending 0/0 spans with 1000/44505 events
2020/02/25 10:17:39 recorder.go:174: sending 0/0 spans with 1000/43505 events
2020/02/25 10:17:40 recorder.go:174: sending 0/0 spans with 1000/42505 events
2020/02/25 10:17:41 recorder.go:174: sending 0/0 spans with 1000/41505 events
2020/02/25 10:17:42 recorder.go:174: sending 0/0 spans with 1000/40505 events
2020/02/25 10:17:42 recorder.go:174: sending 0/0 spans with 1000/39505 events
2020/02/25 10:17:43 recorder.go:174: sending 0/0 spans with 1000/38505 events
2020/02/25 10:17:44 recorder.go:174: sending 0/0 spans with 1000/37505 events
2020/02/25 10:17:44 recorder.go:174: sending 0/0 spans with 1000/36505 events
2020/02/25 10:17:45 recorder.go:174: sending 0/0 spans with 1000/35505 events
2020/02/25 10:17:46 recorder.go:174: sending 0/0 spans with 1000/34505 events
2020/02/25 10:17:47 recorder.go:174: sending 0/0 spans with 1000/33505 events
2020/02/25 10:17:48 recorder.go:174: sending 0/0 spans with 1000/32505 events
2020/02/25 10:17:49 recorder.go:174: sending 0/0 spans with 1000/31505 events
2020/02/25 10:17:50 recorder.go:174: sending 0/0 spans with 1000/30505 events
2020/02/25 10:17:50 recorder.go:174: sending 0/0 spans with 1000/29505 events
2020/02/25 10:17:51 recorder.go:174: sending 0/0 spans with 1000/28505 events
2020/02/25 10:17:52 recorder.go:174: sending 0/0 spans with 1000/27505 events
2020/02/25 10:17:52 recorder.go:174: sending 0/0 spans with 1000/26505 events
2020/02/25 10:17:53 recorder.go:174: sending 0/0 spans with 1000/25505 events
2020/02/25 10:17:54 recorder.go:174: sending 0/0 spans with 1000/24505 events
2020/02/25 10:17:55 recorder.go:174: sending 0/0 spans with 1000/23505 events
2020/02/25 10:17:55 recorder.go:174: sending 0/0 spans with 1000/22505 events
2020/02/25 10:17:56 recorder.go:174: sending 0/0 spans with 1000/21505 events
2020/02/25 10:17:57 recorder.go:174: sending 0/0 spans with 1000/20505 events
2020/02/25 10:17:57 recorder.go:174: sending 0/0 spans with 1000/19505 events
2020/02/25 10:17:58 recorder.go:174: sending 0/0 spans with 1000/18505 events
2020/02/25 10:17:59 recorder.go:174: sending 0/0 spans with 1000/17505 events
2020/02/25 10:17:59 recorder.go:174: sending 0/0 spans with 1000/16505 events
2020/02/25 10:18:00 recorder.go:174: sending 0/0 spans with 1000/15505 events
2020/02/25 10:18:01 recorder.go:174: sending 0/0 spans with 1000/14505 events
2020/02/25 10:18:01 recorder.go:174: sending 0/0 spans with 1000/13505 events
2020/02/25 10:18:02 recorder.go:174: sending 0/0 spans with 1000/12505 events
2020/02/25 10:18:03 recorder.go:174: sending 0/0 spans with 1000/11505 events
2020/02/25 10:18:03 recorder.go:174: sending 0/0 spans with 1000/10505 events
2020/02/25 10:18:04 recorder.go:174: sending 0/0 spans with 1000/9505 events
2020/02/25 10:18:05 recorder.go:174: sending 0/0 spans with 1000/8505 events
2020/02/25 10:18:06 recorder.go:174: sending 0/0 spans with 1000/7505 events
2020/02/25 10:18:06 recorder.go:174: sending 0/0 spans with 1000/6505 events
2020/02/25 10:18:07 recorder.go:174: sending 0/0 spans with 1000/5505 events
2020/02/25 10:18:08 recorder.go:174: sending 0/0 spans with 1000/4505 events
2020/02/25 10:18:08 recorder.go:174: sending 0/0 spans with 1000/3505 events
2020/02/25 10:18:09 recorder.go:174: sending 0/0 spans with 1000/2505 events
2020/02/25 10:18:10 recorder.go:174: sending 0/0 spans with 1000/1505 events
2020/02/25 10:18:11 recorder.go:174: sending 0/0 spans with 505/505 events
2020/02/25 10:18:12 recorder.go:106: recorder has been stopped.
```
