### PR TITLE
Disable `t.Parallel` with env vars in the auto instrumentation

### DIFF
--- a/env/vars.go
+++ b/env/vars.go
@@ -17,6 +17,7 @@ var (
 	ScopeTestingMode                      = newBooleanEnvVar(false, "SCOPE_TESTING_MODE")
 	ScopeTestingFailRetries               = newIntEnvVar(0, "SCOPE_TESTING_FAIL_RETRIES")
 	ScopeTestingPanicAsFail               = newBooleanEnvVar(false, "SCOPE_TESTING_PANIC_AS_FAIL")
+	ScopeTestingDisableParallel           = newBooleanEnvVar(false, "SCOPE_TESTING_DISABLE_PARALLEL")
 	ScopeConfiguration                    = newSliceEnvVar([]string{tags.PlatformName, tags.PlatformArchitecture, tags.GoVersion}, "SCOPE_CONFIGURATION")
 	ScopeMetadata                         = newMapEnvVar(nil, "SCOPE_METADATA")
 	ScopeInstrumentationHttpPayloads      = newBooleanEnvVar(false, "SCOPE_INSTRUMENTATION_HTTP_PAYLOADS")


### PR DESCRIPTION
This `PR` adds the `SCOPE_TESTING_DISABLE_PARALLEL` environment variable to disable calls to `t.Parallel()` when the auto instrumentation is used.

This is useful when we want to get the Code Path on those tests from the GH Action without changing the source code.