### PR TITLE
Parallel flag detector for Code Path

### DIFF
--- a/instrumentation/testing/init.go
+++ b/instrumentation/testing/init.go
@@ -1,14 +1,27 @@
 package testing
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 
+	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/reflection"
+)
+
+var (
+	parallel int
 )
 
 // Initialize the testing instrumentation
 func Init(m *testing.M) {
+	flag.Parse()
+	fPtr := flag.Lookup("test.parallel")
+	if fPtr != nil {
+		parallel = (*fPtr).Value.(flag.Getter).Get().(int)
+		instrumentation.Logger().Println("parallel flag set to:", parallel)
+	}
+
 	if tPointer, err := reflection.GetFieldPointerOf(m, "tests"); err == nil {
 		intTests := (*[]testing.InternalTest)(tPointer)
 		tests := make([]testing.InternalTest, 0)

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -163,7 +163,7 @@ func (test *Test) end() {
 
 	if testing.CoverMode() != "" {
 		// Checks if the current test is running parallel to extract the coverage or not
-		if reflection.GetIsParallel(test.t) {
+		if reflection.GetIsParallel(test.t) && parallel > 1 {
 			instrumentation.Logger().Printf("CodePath in parallel test is not supported: %v\n", test.t.Name())
 			restoreCoverageCounters()
 		} else if cov := endCoverage(); cov != nil {


### PR DESCRIPTION
This `PR` enables detection of the `-parallel` flag in `go test` for enabling Code Path if flag is set to 1.

This is useful when we want to get the Code Path on those tests from the GH Action without changing the source code.