### PR TITLE
Send metadata until at least one payload is successfully delivered

### DIFF
--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -156,6 +156,7 @@ func (r *SpanRecorder) sendSpans() (error, bool) {
 			r.logger.Println("adding payload metadata")
 			payload["metadata"] = r.metadata
 		}
+
 		buf, err := msgPackEncodePayload(payload)
 		if err != nil {
 			atomic.AddInt64(&r.stats.sendSpansKo, 1)

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -28,14 +28,13 @@ type (
 		sync.RWMutex
 		t tomb.Tomb
 
-		agentId      string
-		apiKey       string
-		apiEndpoint  string
-		version      string
-		userAgent    string
-		debugMode    bool
-		metadata     map[string]interface{}
-		metadataOnce sync.Once
+		agentId     string
+		apiKey      string
+		apiEndpoint string
+		version     string
+		userAgent   string
+		debugMode   bool
+		metadata    map[string]interface{}
 
 		payloadSpans  []PayloadSpan
 		payloadEvents []PayloadEvent
@@ -153,11 +152,10 @@ func (r *SpanRecorder) sendSpans() (error, bool) {
 			tags.AgentID: r.agentId,
 		}
 
-		// We send the metadata only in the first payload
-		r.metadataOnce.Do(func() {
+		if atomic.LoadInt64(&r.stats.sendSpansOk) == 0 {
+			r.logger.Println("adding payload metadata")
 			payload["metadata"] = r.metadata
-		})
-
+		}
 		buf, err := msgPackEncodePayload(payload)
 		if err != nil {
 			atomic.AddInt64(&r.stats.sendSpansKo, 1)


### PR DESCRIPTION
This `PR` enables the recorder to send the metadata in the payload until at least one span is delivered successfully.
