### PR TITLE
Ensure the correct folder permissions when creating log folders

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -424,7 +424,7 @@ func getLogPath() (string, error) {
 	if logFolder != "" {
 		if _, err := os.Stat(logFolder); err == nil {
 			return logFolder, nil
-		} else if os.IsNotExist(err) && os.Mkdir(logFolder, os.ModeDir) == nil {
+		} else if os.IsNotExist(err) && os.Mkdir(logFolder, 0755) == nil {
 			return logFolder, nil
 		}
 	}
@@ -433,7 +433,7 @@ func getLogPath() (string, error) {
 	logFolder = path.Join(os.TempDir(), "scope")
 	if _, err := os.Stat(logFolder); err == nil {
 		return logFolder, nil
-	} else if os.IsNotExist(err) && os.Mkdir(logFolder, os.ModeDir) == nil {
+	} else if os.IsNotExist(err) && os.Mkdir(logFolder, 0755) == nil {
 		return logFolder, nil
 	} else {
 		return "", err


### PR DESCRIPTION
This `PR` changes the folder permissions when creating the folder for the log path. Currently was only setting `d---------`, with this change we create the folder with `drwxr-xr-x`