### PR TITLE
Goroutines global panic handler

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -393,6 +393,15 @@ func (a *Agent) Stop() {
 	a.PrintReport()
 }
 
+// Flush agent buffer
+func (a *Agent) Flush() {
+	a.logger.Println("Flushing agent buffer...")
+	err := a.recorder.Flush()
+	if err != nil {
+		a.logger.Println(err)
+	}
+}
+
 func generateAgentID() string {
 	agentId, err := uuid.NewRandom()
 	if err != nil {

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -203,6 +203,15 @@ func (r *SpanRecorder) Stop() {
 	}
 }
 
+// Flush recorder
+func (r *SpanRecorder) Flush() error {
+	if r.debugMode {
+		r.logger.Println("Flushing recorder buffer...")
+	}
+	err, _ := r.sendSpans()
+	return err
+}
+
 // Write statistics
 func (r *SpanRecorder) writeStats() {
 	r.statsOnce.Do(func() {

--- a/reflection/panic_handler.go
+++ b/reflection/panic_handler.go
@@ -1,0 +1,84 @@
+package reflection
+
+import (
+	"reflect"
+	"sync"
+	"unsafe"
+	_ "unsafe"
+
+	"github.com/undefinedlabs/go-mpatch"
+)
+
+var (
+	patchOnPanic    *mpatch.Patch
+	mOnPanic        sync.Mutex
+	onPanicHandlers []func(e interface{})
+
+	patchOnExit   *mpatch.Patch
+	mOnExit       sync.Mutex
+	onExitHandler []func(e interface{})
+)
+
+// Adds a global panic handler (this handler will be executed before any recover call)
+func AddPanicHandler(fn func(interface{})) {
+	mOnPanic.Lock()
+	defer mOnPanic.Unlock()
+	if patchOnPanic == nil {
+		gp := lgopanic
+		np, err := mpatch.PatchMethodByReflect(reflect.Method{Func: reflect.ValueOf(gp)}, gopanic)
+		if err == nil {
+			patchOnPanic = np
+		}
+	}
+	onPanicHandlers = append(onPanicHandlers, fn)
+}
+
+// Adds a global panic handler before process kill (this handler will be executed if not recover is set before the process exits)
+func AddOnPanicExitHandler(fn func(interface{})) {
+	mOnExit.Lock()
+	defer mOnExit.Unlock()
+	if patchOnExit == nil {
+		gp := lpreprintpanics
+		np, err := mpatch.PatchMethodByReflect(reflect.Method{Func: reflect.ValueOf(gp)}, preprintpanics)
+		if err == nil {
+			patchOnExit = np
+		}
+	}
+	onExitHandler = append(onExitHandler, fn)
+}
+
+func gopanic(e interface{}) {
+	mOnPanic.Lock()
+	defer mOnPanic.Unlock()
+	for _, fn := range onPanicHandlers {
+		fn(e)
+	}
+	patchOnPanic.Unpatch()
+	defer patchOnPanic.Patch()
+	lgopanic(e)
+}
+
+func preprintpanics(p *_panic) {
+	mOnExit.Lock()
+	defer mOnExit.Unlock()
+	for _, fn := range onExitHandler {
+		fn(p.arg)
+	}
+	patchOnExit.Unpatch()
+	defer patchOnExit.Patch()
+	lpreprintpanics(p)
+}
+
+//go:linkname lgopanic runtime.gopanic
+func lgopanic(e interface{})
+
+//go:linkname lpreprintpanics runtime.preprintpanics
+func lpreprintpanics(p *_panic)
+
+type _panic struct {
+	argp      unsafe.Pointer // pointer to arguments of deferred call run during panic; cannot move - known to liblink
+	arg       interface{}    // argument to panic
+	link      *_panic        // link to earlier panic
+	recovered bool           // whether this panic is over
+	aborted   bool           // the panic was aborted
+}

--- a/reflection/panic_handler_test.go
+++ b/reflection/panic_handler_test.go
@@ -1,0 +1,37 @@
+package reflection
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestPanicHandler(t *testing.T) {
+	panicHandlerVisit := 0
+
+	AddPanicHandler(func(e interface{}) {
+		fmt.Println("PANIC HANDLER FOR:", e)
+		panicHandlerVisit++
+	})
+
+	t.Run("OnPanic", func(t *testing.T) {
+		go func() {
+
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Println("PANIC RECOVERED")
+				}
+			}()
+
+			fmt.Println("PANICKING!")
+			panic("Panic error")
+
+		}()
+
+		time.Sleep(1 * time.Second)
+	})
+
+	if panicHandlerVisit != 1 {
+		t.Fatalf("panic handler should be executed once.")
+	}
+}

--- a/reflection/panic_handler_test.go
+++ b/reflection/panic_handler_test.go
@@ -2,16 +2,17 @@ package reflection
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestPanicHandler(t *testing.T) {
-	panicHandlerVisit := 0
+	var panicHandlerVisit int32
 
 	AddPanicHandler(func(e interface{}) {
 		fmt.Println("PANIC HANDLER FOR:", e)
-		panicHandlerVisit++
+		atomic.AddInt32(&panicHandlerVisit, 1)
 	})
 
 	t.Run("OnPanic", func(t *testing.T) {
@@ -31,7 +32,7 @@ func TestPanicHandler(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	})
 
-	if panicHandlerVisit != 1 {
+	if atomic.LoadInt32(&panicHandlerVisit) != 1 {
 		t.Fatalf("panic handler should be executed once.")
 	}
 }

--- a/reflection/panic_handler_test.go
+++ b/reflection/panic_handler_test.go
@@ -1,30 +1,32 @@
-package reflection
+package reflection_test
 
 import (
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	_ "go.undefinedlabs.com/scopeagent/autoinstrument"
+	"go.undefinedlabs.com/scopeagent/reflection"
 )
 
 func TestPanicHandler(t *testing.T) {
 	var panicHandlerVisit int32
 
-	AddPanicHandler(func(e interface{}) {
-		fmt.Println("PANIC HANDLER FOR:", e)
+	reflection.AddPanicHandler(func(e interface{}) {
+		t.Log("PANIC HANDLER FOR:", e)
 		atomic.AddInt32(&panicHandlerVisit, 1)
 	})
 
-	t.Run("OnPanic", func(t *testing.T) {
+	t.Run("OnPanic", func(t2 *testing.T) {
 		go func() {
 
 			defer func() {
 				if r := recover(); r != nil {
-					fmt.Println("PANIC RECOVERED")
+					t.Log("PANIC RECOVERED")
 				}
 			}()
 
-			fmt.Println("PANICKING!")
+			t.Log("PANICKING!")
 			panic("Panic error")
 
 		}()


### PR DESCRIPTION
Currently when a test starts a new goroutine, and this goroutine panics, all process crashes without any signal so the data inside the recorder's buffer is lost. This let us without data for the missing tests for that execution and possible failures being hidden by the missing data.

This `PR` adds a new goroutines global panic handler allowing to fail running tests and flush the recorder buffer before process exit.

When a panic occurs in any goroutine, the following is executed:

1) Panic event!
2) Handlers registered with `AddPanicHandler` are executed
3) If the panic is handled and recovered by the goroutine the execution continues...
4) If the panic is unhandled the process will crash, before crashing all handlers registered with `AddOnPanicExitHandler ` are executed.
5) Process end with an exit code != 0

For this `PR` before crashing we finish all running tests with status `Fail` and write the panic info as an exception in each one.