### PR TITLE
Forbid empty sourceroot and go.mod path finder

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -299,14 +299,12 @@ func NewAgent(options ...Option) (*Agent, error) {
 		if sRootEx, err := homedir.Expand(cSRoot); err == nil {
 			cSRoot = sRootEx
 		}
-		if cSRoot == "" {
-			cSRoot = getGoModDir()
-		}
 		sourceRoot = cSRoot
-		agent.metadata[tags.SourceRoot] = sourceRoot
-	} else {
-		agent.metadata[tags.SourceRoot] = getGoModDir()
 	}
+	if sourceRoot == "" {
+		sourceRoot = getGoModDir()
+	}
+	agent.metadata[tags.SourceRoot] = sourceRoot
 
 	if !agent.testingMode {
 		if env.ScopeTestingMode.IsSet {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -364,7 +364,7 @@ func getGoModDir() string {
 		if rel == "." {
 			return filepath.Dir("/")
 		}
-		modPath := fmt.Sprintf("%v/go2.mod", dir)
+		modPath := fmt.Sprintf("%v/go.mod", dir)
 		if _, err := os.Stat(modPath); err == nil {
 			return dir
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -297,9 +297,15 @@ func NewAgent(options ...Option) (*Agent, error) {
 		cSRoot := sRoot.(string)
 		cSRoot = filepath.Clean(cSRoot)
 		if sRootEx, err := homedir.Expand(cSRoot); err == nil {
-			sourceRoot = sRootEx
-			agent.metadata[tags.SourceRoot] = sRootEx
+			cSRoot = sRootEx
 		}
+		if cSRoot == "" {
+			cSRoot = filepath.Dir("/")
+		}
+		sourceRoot = cSRoot
+		agent.metadata[tags.SourceRoot] = sourceRoot
+	} else {
+		agent.metadata[tags.SourceRoot] = filepath.Dir("/")
 	}
 
 	if !agent.testingMode {


### PR DESCRIPTION
This `PR` adds an additional fallback when the source root can't be detected (to improve the detection of a valid source root). This fallback is based on the path of the `go.mod` file, using the current folder as the starting point and going up from parent to parent folder.

According https://blog.golang.org/using-go-modules the `go.mod` file should be at the root of the project (in case the project is using go modules).

**With this `PR` the source root detector has the following priorities:**

1) `SCOPE_SOURCE_ROOT` environment variable.
2) CI environment variables.
3) `.git` folder root path
4) `go.mod` path
5) `/`

> Note: Each value is tested using `os.Stat` to validate the directory existence, in case the value is set but the directory doesn't exist, then the value is invalid and the next fallback is called.
