### PR TITLE
Global panic handler as an agent option

### DIFF
--- a/autoinstrument/init.go
+++ b/autoinstrument/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/undefinedlabs/go-mpatch"
 
 	"go.undefinedlabs.com/scopeagent"
+	"go.undefinedlabs.com/scopeagent/agent"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 	scopetesting "go.undefinedlabs.com/scopeagent/instrumentation/testing"
 )
@@ -35,7 +36,7 @@ func init() {
 			}()
 			scopetesting.PatchTestingLogger()
 			defer scopetesting.UnpatchTestingLogger()
-			return scopeagent.Run(m)
+			return scopeagent.Run(m, agent.WithGlobalPanicHandler())
 		})
 		logOnError(err)
 	})

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,15 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.5.1
-	github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98
+	github.com/undefinedlabs/go-mpatch v0.0.0-20200326085307-1a86426f42a6
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98 h1:Z/megzdoMbuZ0H/oLmfTw92PAEfyTi1DkvAr8AUzFgw=
 github.com/undefinedlabs/go-mpatch v0.0.0-20200122175732-0044123dbb98/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
+github.com/undefinedlabs/go-mpatch v0.0.0-20200326085307-1a86426f42a6 h1:VO1oVFjnL0fwOlwLpDqY1xhY/cfr0Ycz4aLwWM76D6k=
+github.com/undefinedlabs/go-mpatch v0.0.0-20200326085307-1a86426f42a6/go.mod h1:TyJZDQ/5AgyN7FSLiBJ8RO9u2c6wbtRvK827b6AVqY4=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/init.go
+++ b/init.go
@@ -11,11 +11,9 @@ import (
 	"testing"
 
 	"go.undefinedlabs.com/scopeagent/agent"
-	"go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
 	"go.undefinedlabs.com/scopeagent/instrumentation/logging"
 	scopetesting "go.undefinedlabs.com/scopeagent/instrumentation/testing"
-	"go.undefinedlabs.com/scopeagent/reflection"
 )
 
 var (
@@ -52,15 +50,6 @@ func Run(m *testing.M, opts ...agent.Option) int {
 		newAgent.Stop()
 		os.Exit(1)
 	}()
-	reflection.AddPanicHandler(func(e interface{}) {
-		instrumentation.Logger().Printf("Panic handler triggered by: %v.\nFlushing agent, sending partial results...", errors.GetCurrentError(e).ErrorStack())
-		newAgent.Flush()
-	})
-	reflection.AddOnPanicExitHandler(func(e interface{}) {
-		instrumentation.Logger().Printf("Process is going to end by: %v,\nStopping agent...", errors.GetCurrentError(e).ErrorStack())
-		scopetesting.PanicAllRunningTests(e, 3)
-		newAgent.Stop()
-	})
 
 	defaultAgent = newAgent
 	return newAgent.Run(m)


### PR DESCRIPTION
Closes #207 

This `PR` moves the global panic handler from the `scopeagent.Run` method to an option for the agent, this options it's added in the auto instrumentation by default.

This should fix the okteto problem while compiling for arm64.