### PR TITLE
Avoid accessing 'agent.recoder' if not initialized

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -435,16 +435,19 @@ func (a *Agent) Run(m *testing.M) int {
 // Stops the agent
 func (a *Agent) Stop() {
 	a.logger.Println("Scope agent is stopping gracefully...")
-	a.recorder.Stop()
+	if a.recorder != nil {
+		a.recorder.Stop()
+	}
 	a.PrintReport()
 }
 
 // Flush agent buffer
 func (a *Agent) Flush() {
 	a.logger.Println("Flushing agent buffer...")
-	err := a.recorder.Flush()
-	if err != nil {
-		a.logger.Println(err)
+	if a.recorder != nil {
+		if err := a.recorder.Flush(); err != nil {
+			a.logger.Println(err)
+		}
 	}
 }
 

--- a/agent/report.go
+++ b/agent/report.go
@@ -7,7 +7,7 @@ import (
 
 func (a *Agent) PrintReport() {
 	a.printReportOnce.Do(func() {
-		if a.testingMode && a.recorder.stats.totalTestSpans > 0 {
+		if a.recorder != nil && a.testingMode && a.recorder.stats.totalTestSpans > 0 {
 			fmt.Printf("\n** Scope Test Report **\n")
 			if a.recorder.stats.testSpansNotSent == 0 && a.recorder.stats.testSpansRejected == 0 {
 				fmt.Println("Access the detailed test report for this build at:")


### PR DESCRIPTION
This was an issue reported by Okteto.

If the agent fails to initialize (for example, because there's no API key), `agent.recorder` could still be accessed (for example, by the panic handler added by `WithGlobalPanicHandler`).