### PR TITLE
Local cache struct, NTP cache and improvements in cached tests

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -56,13 +56,15 @@ type (
 
 		logger          *log.Logger
 		printReportOnce sync.Once
+
+		cache *localCache
 	}
 
 	Option func(*Agent)
 )
 
 var (
-	version = "0.3.1-pre1"
+	version = "0.3.1-pre2"
 
 	testingModeFrequency    = time.Second
 	nonTestingModeFrequency = time.Minute
@@ -375,6 +377,9 @@ func NewAgent(options ...Option) (*Agent, error) {
 	if agent.debugMode {
 		agent.logMetadata()
 	}
+
+	//
+	agent.cache = newLocalCache(agent.getRemoteConfigRequest(), cacheTimeout, agent.debugMode, agent.logger)
 
 	agent.recorder = NewSpanRecorder(agent)
 	var recorder tracer.SpanRecorder = agent.recorder

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -69,7 +70,12 @@ func (a *Agent) getOrSetLocalCacheData(metadata map[string]interface{}, key stri
 	// Checks if the cache data is old
 	if useTimeout {
 		fInfo, err := file.Stat()
-		if err != nil || time.Now().Sub(fInfo.ModTime()) > cacheTimeout {
+		if err != nil {
+			return loaderFunc(metadata, err, fn)
+		}
+		sTime := time.Now().Sub(fInfo.ModTime())
+		if sTime > cacheTimeout {
+			err = errors.New(fmt.Sprintf("The local cache key '%s' has timeout: %v", path, sTime))
 			return loaderFunc(metadata, err, fn)
 		}
 	}

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -110,11 +110,7 @@ func (c *localCache) GetOrSet(key string, useTimeout bool, fn func(interface{}, 
 	if err := json.Unmarshal(fileBytes, &cItem); err != nil {
 		return loaderFunc(key, err, fn)
 	} else {
-		if c.debugMode {
-			c.logger.Printf("Local cache loading: %s => %s", path, string(fileBytes))
-		} else {
-			c.logger.Printf("Local cache loading: %s", path)
-		}
+		c.logger.Printf("Local cache loaded: %s (%d bytes)", path, len(fileBytes))
 		return cItem.Value
 	}
 }

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -79,7 +79,7 @@ func (c *localCache) GetOrSet(key string, useTimeout bool, fn func(interface{}, 
 
 	path := fmt.Sprintf("%s.%s", c.basePath, key)
 
-	// We try to load the cached version of the remote configuration
+	// We try to load the cached value
 	file, err := os.Open(path)
 	if err != nil {
 		return loaderFunc(key, err, fn)

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const cacheTimeout = 5 * time.Minute
+
+func (a *Agent) getOrSetLocalCacheData(metadata map[string]interface{}, key string, useTimeout bool, fn func(map[string]interface{}) interface{}) interface{} {
+	if metadata == nil {
+		return nil
+	}
+
+	path, err := getLocalCacheFilePath(metadata, key)
+	if err != nil {
+		a.logger.Printf("Local cache: %v", err)
+		return fn(metadata)
+	}
+
+	// Loader function
+	loaderFunc := func(metadata map[string]interface{}, err error, fn func(map[string]interface{}) interface{}) interface{} {
+		if err != nil {
+			a.logger.Printf("Local cache: %v", err)
+		}
+		if fn == nil {
+			return nil
+		}
+
+		// Call the loader
+		resp := fn(metadata)
+
+		if resp != nil {
+			// Get local cache file path
+			path, err := getLocalCacheFilePath(metadata, key)
+			if err != nil {
+				return resp
+			}
+
+			// Save a local cache for the response
+			if data, err := json.Marshal(&resp); err == nil {
+				if a.debugMode {
+					a.logger.Printf("Local cache saving: %s => %s", path, string(data))
+				}
+				if err := ioutil.WriteFile(path, data, 0755); err != nil {
+					a.logger.Printf("Error writing json file: %v", err)
+				}
+			}
+		}
+
+		return resp
+	}
+
+	// We try to load the cached version of the remote configuration
+	file, err := os.Open(path)
+	if err != nil {
+		return loaderFunc(metadata, err, fn)
+	}
+	defer file.Close()
+
+	// Checks if the cache data is old
+	if useTimeout {
+		fInfo, err := file.Stat()
+		if err != nil || time.Now().Sub(fInfo.ModTime()) > cacheTimeout {
+			return loaderFunc(metadata, err, fn)
+		}
+	}
+
+	// Read the cached value
+	fileBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return loaderFunc(metadata, err, fn)
+	}
+
+	// Unmarshal json data
+	var res map[string]interface{}
+	if err := json.Unmarshal(fileBytes, &res); err != nil {
+		return loaderFunc(metadata, err, fn)
+	} else {
+		if a.debugMode {
+			a.logger.Printf("Local cache loading: %s => %s", path, string(fileBytes))
+		} else {
+			a.logger.Printf("Local cache loading: %s", path)
+		}
+		return res
+	}
+}
+
+// Gets the local cache file path
+func getLocalCacheFilePath(metadata map[string]interface{}, key string) (string, error) {
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		return "", err
+	}
+	hash := fmt.Sprintf("%x", sha1.Sum(data))
+
+	var folder string
+	if runtime.GOOS == "windows" {
+		folder = fmt.Sprintf("%s/AppData/Roaming/scope/cache", homeDir)
+	} else {
+		folder = fmt.Sprintf("%s/.scope/cache", homeDir)
+	}
+
+	if _, err := os.Stat(folder); err == nil {
+		return filepath.Join(folder, fmt.Sprintf("%s.%s", hash, key)), nil
+	} else if os.IsNotExist(err) {
+		err = os.MkdirAll(folder, 0755)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(folder, fmt.Sprintf("%s.%s", hash, key)), nil
+	} else {
+		return "", err
+	}
+}

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -33,7 +33,7 @@ type (
 )
 
 // Create a new local cache
-func newLocalCache(tenant map[string]interface{}, timeout time.Duration, debugMode bool, logger *log.Logger) *localCache {
+func newLocalCache(tenant interface{}, timeout time.Duration, debugMode bool, logger *log.Logger) *localCache {
 	lc := &localCache{
 		timeout:   timeout,
 		debugMode: debugMode,

--- a/agent/cache.go
+++ b/agent/cache.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-const cacheTimeout = 5 * time.Minute
+const cacheTimeout = 1 * time.Minute
 
 type (
 	localCache struct {

--- a/agent/cache_test.go
+++ b/agent/cache_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func getTenant() interface{} {
+	return map[string]string{
+		"key1": "value1",
+		"key2": fmt.Sprintf("%v", time.Now()),
+	}
+}
+
+func TestLocalCache(t *testing.T) {
+
+	tenant := getTenant()
+
+	cache := newLocalCache(tenant, cacheTimeout, true, log.New(os.Stdout, "", 0))
+	loader := false
+	result := cache.GetOrSet("MyKey01", false, func(i interface{}, s string) interface{} {
+		loader = true
+		return "hello world"
+	})
+
+	if !loader {
+		t.Fatal("loader has not been executed.")
+	}
+	if result.(string) != "hello world" {
+		t.Fatal("result was different than expected.")
+	}
+
+	cache2 := newLocalCache(tenant, cacheTimeout, true, log.New(os.Stdout, "", 0))
+	loader = false
+	for i := 0; i < 10; i++ {
+		result = cache2.GetOrSet("MyKey01", false, func(i interface{}, s string) interface{} {
+			loader = true
+			return "hello world"
+		})
+
+		if loader {
+			t.Fatal("loader has been executed.")
+		}
+		if result.(string) != "hello world" {
+			t.Fatal("result was different than expected.")
+		}
+	}
+}

--- a/agent/ntp.go
+++ b/agent/ntp.go
@@ -44,7 +44,7 @@ func (r *SpanRecorder) applyNTPOffset(t time.Time) time.Time {
 				r.logger.Printf("error calculating the ntp offset: %v\n", err)
 				return nil
 			}
-			return oSet
+			return float64(oSet)
 		})
 		if offset != nil {
 			ntpOffset = time.Duration(offset.(float64))

--- a/agent/ntp.go
+++ b/agent/ntp.go
@@ -9,7 +9,7 @@ import (
 const (
 	server  = "pool.ntp.org"
 	retries = 5
-	timeout = 1 * time.Second
+	timeout = 2 * time.Second
 	backoff = 1 * time.Second
 )
 

--- a/agent/ntp.go
+++ b/agent/ntp.go
@@ -38,12 +38,17 @@ func (r *SpanRecorder) applyNTPOffset(t time.Time) time.Time {
 		if r.debugMode {
 			r.logger.Println("calculating ntp offset.")
 		}
-		offset, err := getNTPOffset()
-		if err == nil {
-			ntpOffset = offset
+		offset := r.cache.GetOrSet("ntp", true, func(d interface{}, s string) interface{} {
+			oSet, err := getNTPOffset()
+			if err != nil {
+				r.logger.Printf("error calculating the ntp offset: %v\n", err)
+				return nil
+			}
+			return oSet
+		})
+		if offset != nil {
+			ntpOffset = offset.(time.Duration)
 			r.logger.Printf("ntp offset: %v\n", ntpOffset)
-		} else {
-			r.logger.Printf("error calculating the ntp offset: %v\n", err)
 		}
 	})
 	return t.Add(ntpOffset)

--- a/agent/ntp.go
+++ b/agent/ntp.go
@@ -47,7 +47,7 @@ func (r *SpanRecorder) applyNTPOffset(t time.Time) time.Time {
 			return oSet
 		})
 		if offset != nil {
-			ntpOffset = offset.(time.Duration)
+			ntpOffset = time.Duration(offset.(float64))
 			r.logger.Printf("ntp offset: %v\n", ntpOffset)
 		}
 	})

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -46,6 +46,7 @@ type (
 		logger    *log.Logger
 		stats     *RecorderStats
 		statsOnce sync.Once
+		cache     *localCache
 	}
 	RecorderStats struct {
 		totalSpans        int64
@@ -76,6 +77,7 @@ func NewSpanRecorder(agent *Agent) *SpanRecorder {
 	r.debugMode = agent.debugMode
 	r.metadata = agent.metadata
 	r.logger = agent.logger
+	r.cache = agent.cache
 	r.flushFrequency = agent.flushFrequency
 	r.url = agent.getUrl("api/agent/ingest")
 	r.client = &http.Client{}

--- a/agent/remote_config.go
+++ b/agent/remote_config.go
@@ -24,14 +24,9 @@ func (a *Agent) loadRemoteConfiguration() map[string]interface{} {
 		jsBytes, _ := json.Marshal(configRequest)
 		a.logger.Printf("Getting remote configuration for: %v", string(jsBytes))
 	}
-
-	a.getOrSetLocalCacheData(configRequest, "test", true, func(m map[string]interface{}) interface{} {
-		return "Hello World"
-	})
-
-	config := a.getOrSetLocalCacheData(configRequest, "remote", false, a.getRemoteConfiguration)
-	if config != nil {
-		return config.(map[string]interface{})
+	configResponse := a.getOrSetLocalCacheData(configRequest, "remote", false, a.getRemoteConfiguration)
+	if configResponse != nil {
+		return configResponse.(map[string]interface{})
 	}
 	return nil
 }

--- a/agent/util.go
+++ b/agent/util.go
@@ -35,7 +35,7 @@ func getSourceRootFromEnv(key string) string {
 }
 
 // Encodes `payload` using msgpack and compress it with gzip
-func msgPackEncodePayload(payload map[string]interface{}) (*bytes.Buffer, error) {
+func msgPackEncodePayload(payload interface{}) (*bytes.Buffer, error) {
 	binaryPayload, err := msgpack.Marshal(payload)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR introduces a new `localCache` struct as a generic object to store local results between go modules to reduce network roundtrip, currently is enabled for remote configuration (ITR cached tests) and to NTP request with a timeout of 1 minute.

This PR also includes a simple refactor in the span creation for cached tests.