### PR TITLE
Remove unused defaultAgent var

### DIFF
--- a/init.go
+++ b/init.go
@@ -19,7 +19,6 @@ import (
 )
 
 var (
-	defaultAgent *agent.Agent
 	runningMutex sync.RWMutex
 	running      bool
 )
@@ -57,7 +56,6 @@ func Run(m *testing.M, opts ...agent.Option) int {
 		os.Exit(1)
 	}()
 
-	defaultAgent = newAgent
 	return newAgent.Run(m)
 }
 


### PR DESCRIPTION
To avoid an `staticcheck` error (https://staticcheck.io/docs/) this PR removes the unused variable.

```bash
➜  go-agent git:(master) ✗ ~/go/bin/staticcheck
init.go:22:2: var defaultAgent is unused (U1000)
```

with this PR:

```bash
➜  go-agent git:(master) ✗ ~/go/bin/staticcheck -f stylish               
 ✖ 0 problems (0 errors, 0 warnings, 0 ignored)

➜  go-agent git:(master) ✗ ~/go/bin/staticcheck -f stylish -show-ignored
 ✖ 0 problems (0 errors, 0 warnings, 0 ignored)
```