### PR TITLE
Gocheck benchmark support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,6 +35,13 @@ jobs:
           SCOPE_TESTING_FAIL_RETRIES: 3
           SCOPE_TESTING_PANIC_AS_FAIL: true
 
+      - name: Go check benchmark
+        run: go test -gocheck.b
+        env:
+          SCOPE_DSN: ${{ secrets.SCOPE_DSN }}
+          SCOPE_LOGGER_ROOT: /home/runner/.scope-results
+          SCOPE_DEBUG: true
+
       - name: Upload Scope logs
         if: always()
         uses: actions/upload-artifact@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Go check benchmark
         run: go test ./instrumentation/gocheck -gocheck.b -v
+        if: matrix.os == 'ubuntu-latest'
         env:
           SCOPE_DSN: ${{ secrets.SCOPE_DSN }}
           SCOPE_LOGGER_ROOT: /home/runner/.scope-results

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
           SCOPE_TESTING_PANIC_AS_FAIL: true
 
       - name: Go check benchmark
-        run: go test -gocheck.b
+        run: go test ./instrumentation/gocheck -gocheck.b -v
         env:
           SCOPE_DSN: ${{ secrets.SCOPE_DSN }}
           SCOPE_LOGGER_ROOT: /home/runner/.scope-results

--- a/instrumentation/gocheck/gocheck_test.go
+++ b/instrumentation/gocheck/gocheck_test.go
@@ -73,3 +73,8 @@ func (s *MySuite) TestError(c *C) {
 		c.Error("This is an error")
 	}
 }
+func (s *MySuite) BenchmarkLogic(c *C) {
+	for i := 0; i < c.N; i++ {
+		c.Assert("asd", Equals, "asd")
+	}
+}

--- a/instrumentation/gocheck/types.go
+++ b/instrumentation/gocheck/types.go
@@ -124,9 +124,6 @@ func lTestingT(testingT *testing.T)
 //go:linkname writeLog gopkg.in/check%2ev1.(*C).writeLog
 func writeLog(c *chk.C, buf []byte)
 
-///go:linkname lrunTest gopkg.in/check%2ev1.(*suiteRunner).runTest
-//func lrunTest(runner *suiteRunner, method *methodType) *chk.C
-
 //go:linkname lreportCallDone gopkg.in/check%2ev1.(*suiteRunner).reportCallDone
 func lreportCallDone(runner *suiteRunner, c *chk.C)
 


### PR DESCRIPTION
This `PR` adds benchmark support to the gocheck instrumentation.

- Url: https://shared.scope.dev/dashboard/8cee2622-8772-4338-8d72-63653e0e0239/2205d752-62a8-45e8-b12d-5b40f3cc4c71/default/explore/inspect/411452b684954a1e03d1a8d17fca7d3055587ea8/31183ec7-1c0d-4191-a112-7e940e9af46f/trace?spanId=026e33f4-b353-b280-b241-a20e4e4b7efd
![image](https://user-images.githubusercontent.com/69803/83399735-02145c00-a402-11ea-888f-7297af3d467a.png)


- Test and Benchmark support: https://shared.scope.dev/dashboard/8cee2622-8772-4338-8d72-63653e0e0239/2205d752-62a8-45e8-b12d-5b40f3cc4c71/default/explore/inspect/411452b684954a1e03d1a8d17fca7d3055587ea8/
![image](https://user-images.githubusercontent.com/69803/83399786-18221c80-a402-11ea-9bc1-bdea3bee7b29.png)
