### PR TITLE
Removes the SetRand to uuid

### DIFF
--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -200,7 +200,7 @@ ReferencesLoop:
 	if sp.raw.Context.TraceID.String() == emptyUUID {
 		// No parent Span found; allocate new trace and span ids and determine
 		// the Sampled status.
-		sp.raw.Context.TraceID = getRandomUUID()
+		sp.raw.Context.TraceID = uuid.New()
 		sp.raw.Context.SpanID = getRandomId()
 		sp.raw.Context.Sampled = t.options.ShouldSample(sp.raw.Context.TraceID)
 	}

--- a/tracer/util.go
+++ b/tracer/util.go
@@ -25,12 +25,6 @@ func getRandomId() uint64 {
 	return random.Uint64()
 }
 
-func getRandomUUID() uuid.UUID {
-	mu.Lock()
-	defer mu.Unlock()
-	return uuid.New()
-}
-
 func ensureRandom() {
 	if random == nil {
 		random = rand.New(&safeSource{

--- a/tracer/util.go
+++ b/tracer/util.go
@@ -28,7 +28,6 @@ func getRandomId() uint64 {
 func getRandomUUID() uuid.UUID {
 	mu.Lock()
 	defer mu.Unlock()
-	ensureRandom()
 	return uuid.New()
 }
 
@@ -37,7 +36,6 @@ func ensureRandom() {
 		random = rand.New(&safeSource{
 			source: rand.NewSource(getSeed()),
 		})
-		uuid.SetRand(random)
 	}
 }
 


### PR DESCRIPTION
This PR removes the `uuid.SetRand` and let the uuid package to uses the default uuid generator