### PR TITLE
Avoid Complex objects on Span tags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
           SCOPE_LOGGER_ROOT: /home/runner/.scope-results
           SCOPE_DEBUG: true
           SCOPE_RUNNER_ENABLED: true
-          SCOPE_RUNNER_EXCLUDE_BRANCHES: master, complex-objects
+          SCOPE_RUNNER_EXCLUDE_BRANCHES: master
           SCOPE_TESTING_FAIL_RETRIES: 3
           SCOPE_TESTING_PANIC_AS_FAIL: true
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
           SCOPE_LOGGER_ROOT: /home/runner/.scope-results
           SCOPE_DEBUG: true
           SCOPE_RUNNER_ENABLED: true
-          SCOPE_RUNNER_EXCLUDE_BRANCHES: master
+          SCOPE_RUNNER_EXCLUDE_BRANCHES: master, complex-objects
           SCOPE_TESTING_FAIL_RETRIES: 3
           SCOPE_TESTING_PANIC_AS_FAIL: true
 

--- a/errors/handler.go
+++ b/errors/handler.go
@@ -16,14 +16,6 @@ import (
 	"go.undefinedlabs.com/scopeagent/tracer"
 )
 
-const (
-	EventType      = "event"
-	EventSource    = "source"
-	EventMessage   = "message"
-	EventStack     = "stack"
-	EventException = "exception"
-)
-
 type StackFrames struct {
 	File       string
 	LineNumber int
@@ -136,11 +128,11 @@ func getExceptionLogFields(eventType string, recoverData interface{}, skipFrames
 		}
 
 		fields := make([]log.Field, 5)
-		fields[0] = log.String(EventType, eventType)
-		fields[1] = log.String(EventSource, source)
-		fields[2] = log.String(EventMessage, errMessage)
-		fields[3] = log.String(EventStack, getStringStack(err, errStack))
-		fields[4] = log.Object(EventException, exceptionData)
+		fields[0] = log.String(tags.EventType, eventType)
+		fields[1] = log.String(tags.EventSource, source)
+		fields[2] = log.String(tags.EventMessage, errMessage)
+		fields[3] = log.String(tags.EventStack, getStringStack(err, errStack))
+		fields[4] = log.Object(tags.EventException, exceptionData)
 		return fields
 	}
 	return nil

--- a/instrumentation/gocheck/instrumentation.go
+++ b/instrumentation/gocheck/instrumentation.go
@@ -15,6 +15,7 @@ import (
 	"go.undefinedlabs.com/scopeagent/instrumentation/coverage"
 	"go.undefinedlabs.com/scopeagent/instrumentation/logging"
 	"go.undefinedlabs.com/scopeagent/tags"
+	scopetracer "go.undefinedlabs.com/scopeagent/tracer"
 
 	chk "gopkg.in/check.v1"
 )
@@ -103,7 +104,11 @@ func (test *Test) end(c *chk.C) {
 
 	if testing.CoverMode() != "" {
 		if cov := coverage.EndCoverage(); cov != nil {
-			test.span.SetTag(tags.Coverage, *cov)
+			if span, ok := test.span.(scopetracer.Span); ok {
+				span.UnsafeSetTag(tags.Coverage, *cov)
+			} else {
+				test.span.SetTag(tags.Coverage, *cov)
+			}
 		}
 	}
 

--- a/instrumentation/grpc/client.go
+++ b/instrumentation/grpc/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	scopetracer "go.undefinedlabs.com/scopeagent/tracer"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -214,6 +215,8 @@ func (cs *openTracingClientStream) Header() (metadata.MD, error) {
 	md, err := cs.ClientStream.Header()
 	if err != nil {
 		cs.finishFunc(err)
+	} else if span, ok := cs.span.(scopetracer.Span); ok {
+		span.UnsafeSetTag(Headers, md)
 	} else {
 		cs.span.SetTag(Headers, md)
 	}

--- a/instrumentation/grpc/errors.go
+++ b/instrumentation/grpc/errors.go
@@ -88,12 +88,12 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	if value, ok := codeStrings[code]; ok {
 		span.SetTag(Status, value)
 	} else {
-		span.SetTag(Status, code)
+		span.SetTag(Status, uint32(code))
 	}
 	if value, ok := classStrings[c]; ok {
 		span.SetTag("response_class", value)
 	} else {
-		span.SetTag("response_class", c)
+		span.SetTag("response_class", string(c))
 	}
 
 	if err == nil {

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -16,6 +16,7 @@ import (
 
 	scopeerrors "go.undefinedlabs.com/scopeagent/errors"
 	"go.undefinedlabs.com/scopeagent/instrumentation"
+	scopetracer "go.undefinedlabs.com/scopeagent/tracer"
 )
 
 type contextKey int
@@ -183,7 +184,9 @@ func (t *Transport) doRoundTrip(req *http.Request) (*http.Response, error) {
 	tracer.start(req)
 
 	if t.Stacktrace {
-		tracer.sp.SetTag("stacktrace", scopeerrors.GetCurrentStackTrace(2))
+		if span, ok := tracer.sp.(scopetracer.Span); ok {
+			span.UnsafeSetTag("stacktrace", scopeerrors.GetCurrentStackTrace(2))
+		}
 	}
 
 	ext.HTTPMethod.Set(tracer.sp, req.Method)

--- a/instrumentation/nethttp/client.go
+++ b/instrumentation/nethttp/client.go
@@ -186,6 +186,8 @@ func (t *Transport) doRoundTrip(req *http.Request) (*http.Response, error) {
 	if t.Stacktrace {
 		if span, ok := tracer.sp.(scopetracer.Span); ok {
 			span.UnsafeSetTag("stacktrace", scopeerrors.GetCurrentStackTrace(2))
+		} else {
+			tracer.sp.SetTag("stacktrace", scopeerrors.GetCurrentStackTrace(2))
 		}
 	}
 

--- a/instrumentation/sql/driver.go
+++ b/instrumentation/sql/driver.go
@@ -146,7 +146,7 @@ func (t *driverConfiguration) newSpan(operationName string, query string, args [
 			}
 			dbParams[name] = map[string]interface{}{
 				"type":  reflect.TypeOf(item.Value).String(),
-				"value": item.Value,
+				"value": fmt.Sprint(item.Value),
 			}
 		}
 		opts = append(opts, opentracing.Tags{

--- a/instrumentation/testing/benchmark.go
+++ b/instrumentation/testing/benchmark.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"go.undefinedlabs.com/scopeagent/tags"
 	"math"
 	"regexp"
 	"runtime"
@@ -141,9 +142,9 @@ func startBenchmark(b *testing.B, pc uintptr, benchFunc func(b *testing.B)) {
 	span.SetTag("benchmark.memory.mean_allocations", results.AllocsPerOp())
 	span.SetTag("benchmark.memory.mean_bytes_allocations", results.AllocedBytesPerOp())
 	if result {
-		span.SetTag("test.status", "PASS")
+		span.SetTag("test.status", tags.TestStatus_PASS)
 	} else {
-		span.SetTag("test.status", "FAIL")
+		span.SetTag("test.status", tags.TestStatus_FAIL)
 	}
 	span.FinishWithOptions(opentracing.FinishOptions{
 		FinishTime: startTime.Add(results.T),

--- a/instrumentation/testing/testing.go
+++ b/instrumentation/testing/testing.go
@@ -214,7 +214,11 @@ func (test *Test) end() {
 			instrumentation.Logger().Printf("CodePath in parallel test is not supported: %v\n", test.t.Name())
 			coverage.RestoreCoverageCounters()
 		} else if cov := coverage.EndCoverage(); cov != nil {
-			test.span.SetTag(tags.Coverage, *cov)
+			if sp, ok := test.span.(tracer.Span); ok {
+				sp.UnsafeSetTag(tags.Coverage, *cov)
+			} else {
+				test.span.SetTag(tags.Coverage, *cov)
+			}
 		}
 	}
 

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -71,24 +71,24 @@ const (
 	Coverage = "test.coverage"
 )
 
- func GetValidStringValue(value interface{}) (interface{}, bool) {
-	 if value == nil {
-		 return nil, false
-	 }
-	 if vs, ok := value.(fmt.Stringer); ok {
-		 return vs.String(), true
-	 }
-	 rValue := reflect.ValueOf(value)
-	 for {
-		 rKind := rValue.Kind()
-		 if rKind == reflect.Ptr {
-			 rValue = rValue.Elem()
-			 continue
-		 }
-		 if (rKind < 1 || rKind > 16) && rKind != reflect.String {
-			 return fmt.Sprint(value), true
-		 }
-		 break
-	 }
-	 return value, false
- }
+func GetValidStringValue(value interface{}) (interface{}, bool) {
+	if value == nil {
+		return nil, false
+	}
+	if vs, ok := value.(fmt.Stringer); ok {
+		return vs.String(), true
+	}
+	rValue := reflect.ValueOf(value)
+	for {
+		rKind := rValue.Kind()
+		if rKind == reflect.Ptr {
+			rValue = rValue.Elem()
+			continue
+		}
+		if (rKind < 1 || rKind > 16) && rKind != reflect.String {
+			return fmt.Sprint(value), true
+		}
+		break
+	}
+	return value, false
+}

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -1,5 +1,10 @@
 package tags
 
+import (
+	"fmt"
+	"reflect"
+)
+
 const (
 	AgentType    = "agent.type"
 	AgentID      = "agent.id"
@@ -65,3 +70,25 @@ const (
 
 	Coverage = "test.coverage"
 )
+
+ func GetValidStringValue(value interface{}) (interface{}, bool) {
+	 if value == nil {
+		 return nil, false
+	 }
+	 if vs, ok := value.(fmt.Stringer); ok {
+		 return vs.String(), true
+	 }
+	 rValue := reflect.ValueOf(value)
+	 for {
+		 rKind := rValue.Kind()
+		 if rKind == reflect.Ptr {
+			 rValue = rValue.Elem()
+			 continue
+		 }
+		 if (rKind < 1 || rKind > 16) && rKind != reflect.String {
+			 return fmt.Sprint(value), true
+		 }
+		 break
+	 }
+	 return value, false
+ }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -71,7 +71,7 @@ const (
 	Coverage = "test.coverage"
 )
 
-func GetValidStringValue(value interface{}) (interface{}, bool) {
+func GetValidValue(value interface{}) (interface{}, bool) {
 	if value == nil {
 		return nil, false
 	}

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -1,6 +1,8 @@
 package tracer
 
 import (
+	"go.undefinedlabs.com/scopeagent/instrumentation"
+	"go.undefinedlabs.com/scopeagent/tags"
 	"sync"
 	"time"
 
@@ -28,6 +30,9 @@ type Span interface {
 
 	// Log fields with timestamp
 	LogFieldsWithTimestamp(t time.Time, fields ...log.Field)
+
+	// Set tag without validation
+	UnsafeSetTag(key string, value interface{}) opentracing.Span
 }
 
 // Implements the `Span` interface. Created via tracerImpl (see
@@ -85,7 +90,7 @@ func (s *spanImpl) SetStart(start time.Time) opentracing.Span {
 	return s
 }
 
-func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
+func (s *spanImpl) UnsafeSetTag(key string, value interface{}) opentracing.Span {
 	defer s.onTag(key, value)
 	s.Lock()
 	defer s.Unlock()
@@ -104,6 +109,14 @@ func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
 	}
 	s.raw.Tags[key] = value
 	return s
+}
+
+func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
+	cValue, c := tags.GetValidStringValue(value)
+	if c {
+		instrumentation.Logger().Printf("SetTag-ConvertedValue: %v", cValue)
+	}
+	return s.UnsafeSetTag(key, cValue)
 }
 
 func (s *spanImpl) LogKV(keyValues ...interface{}) {

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -1,8 +1,6 @@
 package tracer
 
 import (
-	"go.undefinedlabs.com/scopeagent/instrumentation"
-	"go.undefinedlabs.com/scopeagent/tags"
 	"sync"
 	"time"
 
@@ -11,6 +9,9 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
+
+	"go.undefinedlabs.com/scopeagent/instrumentation"
+	scopetags "go.undefinedlabs.com/scopeagent/tags"
 )
 
 // Span provides access to the essential details of the span, for use
@@ -112,7 +113,7 @@ func (s *spanImpl) UnsafeSetTag(key string, value interface{}) opentracing.Span 
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
-	cValue, c := tags.GetValidStringValue(value)
+	cValue, c := scopetags.GetValidStringValue(value)
 	if c {
 		instrumentation.Logger().Printf("SetTag-ConvertedValue: %v", cValue)
 	}

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -113,7 +113,7 @@ func (s *spanImpl) UnsafeSetTag(key string, value interface{}) opentracing.Span 
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
-	cValue, c := scopetags.GetValidStringValue(value)
+	cValue, c := scopetags.GetValidValue(value)
 	if c {
 		instrumentation.Logger().Printf("SetTag-ConvertedValue: %v", cValue)
 	}


### PR DESCRIPTION
This PR is for avoiding Complex objects on Span tags and enables a new api for that `UnsafeSetTag`.

The complex objects are transformed by the new `GetValidValue` func.