### PR TITLE
Adds locking over the tag map on error reporting and map copy in the reporter

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,7 +64,7 @@ type (
 )
 
 var (
-	version = "0.4.2-pre.1"
+	version = "0.4.2"
 
 	testingModeFrequency    = time.Second
 	nonTestingModeFrequency = time.Minute

--- a/agent/recorder.go
+++ b/agent/recorder.go
@@ -329,6 +329,10 @@ func (r *SpanRecorder) getPayloadComponents(span tracer.RawSpan) (PayloadSpan, [
 	}
 	traceId := tracer.UUIDToString(span.Context.TraceID)
 	spanId := fmt.Sprintf("%x", span.Context.SpanID)
+	tags := opentracing.Tags{}
+	for key, value := range span.Tags {
+		tags[key] = value
+	}
 	payloadSpan := PayloadSpan{
 		"context": map[string]interface{}{
 			"trace_id": traceId,
@@ -339,7 +343,7 @@ func (r *SpanRecorder) getPayloadComponents(span tracer.RawSpan) (PayloadSpan, [
 		"operation":      span.Operation,
 		"start":          r.applyNTPOffset(span.Start).Format(time.RFC3339Nano),
 		"duration":       span.Duration.Nanoseconds(),
-		"tags":           span.Tags,
+		"tags":           tags,
 	}
 	for _, event := range span.Logs {
 		var fields = make(map[string]interface{})

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,29 @@
+package scopeagent_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+
+	"go.undefinedlabs.com/scopeagent"
+	_ "go.undefinedlabs.com/scopeagent/autoinstrument"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func TestFromGoroutineRace(t *testing.T) {
+	ctx := scopeagent.GetContextFromTest(t)
+	span := opentracing.SpanFromContext(ctx)
+
+	for x := 0; x<10;x++ {
+		go func() {
+			for i := 0; i < 100; i++ {
+				span.SetTag(fmt.Sprintf("Key%v", i), i)
+			}
+		}()
+	}
+}

--- a/tracer/span.go
+++ b/tracer/span.go
@@ -210,7 +210,7 @@ func (s *spanImpl) Finish() {
 	if s.tracer != nil && s.tracer.options.OnSpanFinishPanic != nil && s.raw.ParentSpanID != 0 {
 		if r := recover(); r != nil {
 			currentError = errors.Wrap(r, 1)
-			s.tracer.options.OnSpanFinishPanic(&s.raw, &currentError)
+			s.callFinishPanic(&currentError)
 		}
 	}
 
@@ -238,12 +238,18 @@ func rotateLogBuffer(buf []opentracing.LogRecord, pos int) {
 	}
 }
 
+func (s *spanImpl) callFinishPanic(err **errors.Error) {
+	s.Lock()
+	defer s.Unlock()
+	s.tracer.options.OnSpanFinishPanic(&s.raw, err)
+}
+
 func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	var currentError *errors.Error
 	if s.tracer != nil && s.tracer.options.OnSpanFinishPanic != nil && s.raw.ParentSpanID != 0 {
 		if r := recover(); r != nil {
 			currentError = errors.Wrap(r, 1)
-			s.tracer.options.OnSpanFinishPanic(&s.raw, &currentError)
+			s.callFinishPanic(&currentError)
 		}
 	}
 


### PR DESCRIPTION
This `PR` adds locking over the tag map on error reporting and tags map copy in the reporter before releasing the lock